### PR TITLE
Jenkins migration to new system

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -62,8 +62,8 @@ RUN git clone --depth=2 --branch ${SPACK_TAG} https://github.com/spack/spack.git
 RUN . ${SPACK_ROOT}/share/spack/setup-env.sh && \
     spack env create ${SPACK_ENV_NAME} && \
     spack env activate ${SPACK_ENV_NAME} && \
-    spack add trilinos@16.1.0+belos~boost+exodus+hdf5+kokkos+openmp+shared+stk+zoltan+zoltan2 cxxstd=17 %gcc@11.4.0 ^kokkos@4.5.01+hwloc+openmp+serial+shared ^openmpi@4.1.2 && \
-    spack add cmake@3.27.9 && \
+    spack add trilinos@16.1.0+belos~boost+exodus+hdf5+kokkos+openmp+shared+stk+zoltan+zoltan2 cxxstd=17 %gcc@11.4.0 ^kokkos@4.5.01+hwloc+openmp+serial+shared ^openmpi@4.1.2 target=broadwell && \
+    spack add cmake@3.27.9 target=broadwell && \
     spack concretize && \
     spack install && \
     spack load cmake@3.27.9 && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04
+FROM docker.io/nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04
 
 # Reset the nvidia/cuda base image ENTRYPOINT so Jenkins' `docker run ... cat`
 # keep-alive pattern works without triggering the

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,70 +1,35 @@
-pipeline {
-  agent none
-  options {
-    disableConcurrentBuilds()
-    timeout(time: 6, unit: 'HOURS')
-    timestamps()
-  }
-  stages {
-    stage('Build and Test') {
-      agent {
-        dockerfile {
-          filename 'ci/Dockerfile'
-          dir '.'
-          label 'linux'
-        }
-      }
-      environment {
-        HOME = "${WORKSPACE}"
-        MUNDY_DEPS = "${WORKSPACE}/mundy_deps"
-        MUNDY_INSTALL = "${WORKSPACE}/mundy_install"
-        SPACK_ROOT = "/home/testuser/spack"
-        SPACK_TRILINOS = "tril161_cpu"
-        OMPI_MCA_rmaps_base_oversubscribe = "1"
-      }
-      stages {
+properties([
+  disableConcurrentBuilds(),
+  buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30'))
+])
+
+try {
+  timeout(time: 6, unit: 'HOURS') {
+    buildPod(context: 'ci') {
+      withEnv([
+        "HOME=${WORKSPACE}",
+        "MUNDY_DEPS=${WORKSPACE}/mundy_deps",
+        "MUNDY_INSTALL=${WORKSPACE}/mundy_install",
+        "SPACK_ROOT=/home/testuser/spack",
+        "SPACK_TRILINOS=tril161_cpu",
+        "OMPI_MCA_rmaps_base_oversubscribe=1"
+      ]) {
         stage('Build') {
-          steps {
             echo 'Building software inside the container'
             sh './ci/build_jenkins_cpu_release.sh'
-          }
         }
         stage('Test') {
-          steps {
+          try {
             echo 'Executing tests'
             sh './ci/test_jenkins_cpu_release.sh'
+          } finally {
+            junit allowEmptyResults: true, testResults: 'build/ctest_results.xml'
           }
-          post {
-            always {
-              junit allowEmptyResults: true, testResults: 'build/ctest_results.xml'
-            }
-          }
-        }
-      }
-      post {
-        always {
-          cleanWs()
         }
       }
     }
   }
-  post {
-    failure {
-      emailext subject: '$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS',
-      body: '''$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS
-Check console output at $BUILD_URL to view full results.
-Building $BRANCH_NAME for $CAUSE
-$JOB_DESCRIPTION
-Changes:
-$CHANGES
-End of build log:
-${BUILD_LOG,maxLines=200}
-''',
-      recipientProviders: [
-    [$class: 'DevelopersRecipientProvider'],
-    ],
-      replyTo: '$DEFAULT_REPLYTO',
-      to: 'cedelmaier@flatironinstitute.org, bpalmer@flatironinstitute.org'
-      }
-  }
+}
+finally {
+  emailFailure()
 }


### PR DESCRIPTION
This updates the jenkins build to work on the [new system](https://jenkins-new.flatironinstitute.org/job/CCB/job/MuNDy/job/jenkins/). This mainly just changes syntax some. The new system has more hardware and flexibility in resources. I've kept the current default of 4 cores, but this can now be adjusted. Also, since image builds may now happen on a different machine than they run, I had to pin the spack builds to `target=broadwell` to avoid instruction set issues (though I notice it's still picking up cascadelake for some builds -- they right solution is a config file).

Once this is merged, builds will happen on the new system, and stop working on the old system. Then we can remove the old project to avoid duplicate reports on github.