### PR TITLE
Math: Fixed a combinatoric O(N\!) type growth in inverse(mat) via bit…

### DIFF
--- a/mundy/core/math/src/mundy_math/Accessor.hpp
+++ b/mundy/core/math/src/mundy_math/Accessor.hpp
@@ -24,7 +24,6 @@
 // C++ core libs
 #include <concepts>
 #include <cstddef>
-#include <initializer_list>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -175,10 +174,6 @@ concept HasDefaultConstructor = requires { Accessor{}; };
 template <typename Accessor, typename T, size_t N>
 concept HasNArgConstructor =
     impl::can_construct_from_unpacked_tuple<Accessor, decltype(impl::generate_tuple_with_t_repeated_n_times<T, N>())>();
-
-/// \brief A concept that checks if an Accessor is constructible from an initializer list of type T
-template <typename Accessor, typename T>
-concept HasInitializerListConstructor = requires(std::initializer_list<T> list) { Accessor{list}; };
 
 /// @brief  Literal class enums! These are clearer and easier to work with than bools or explicit enums.
 namespace Ownership {

--- a/mundy/core/math/src/mundy_math/Array.hpp
+++ b/mundy/core/math/src/mundy_math/Array.hpp
@@ -27,7 +27,6 @@
 // C++ core
 #include <cmath>
 #include <concepts>
-#include <initializer_list>
 #include <iostream>
 #include <type_traits>
 
@@ -35,7 +34,6 @@
 #include <mundy_math/Tolerance.hpp>  // for mundy::get_zero_tolerance
 #include <mundy_math/impl/ArrayImpl.hpp>
 #include <mundy_utils/requires.hpp>
-#include <mundy_utils/throw_assert.hpp>  // for MUNDY_THROW_ASSERT
 
 namespace mundy {
 
@@ -67,31 +65,15 @@ class Array {
   /// \brief Constructor to initialize all elements explicitly.
   /// Requires the number of arguments to be N and the type of each to be T.
   template <typename... Args>
-      MUNDY_REQUIRES(sizeof...(Args) == N) && (N != 1) &&
-      (std::is_same_v<std::remove_cv_t<std::remove_reference_t<Args>>, T> && ...) KOKKOS_INLINE_FUNCTION
-      constexpr explicit Array(Args&&... args)
+  MUNDY_REQUIRES((sizeof...(Args) == N) && (N != 1) &&
+                 (std::is_same_v<std::remove_cv_t<std::remove_reference_t<Args>>, T> && ...))  //
+  KOKKOS_INLINE_FUNCTION constexpr Array(Args&&... args)
       : data_{std::forward<Args>(args)...} {
-  }
-
-  /// \brief Constructor to initialize all elements via initializer list
-  KOKKOS_INLINE_FUNCTION
-  constexpr Array(const std::initializer_list<T>& list) MUNDY_REQUIRES(!std::is_const_v<T>) {
-    if (list.size() == N) {
-      size_t i = 0;
-      for (auto it = list.begin(); it != list.end(); ++it) {
-        data_[i] = *it;
-        ++i;
-      }
-    } else if (list.size() == 1) {
-      impl::fill_impl(std::make_index_sequence<N>{}, *this, *list.begin());
-    } else {
-      MUNDY_THROW_ASSERT(false, std::invalid_argument, "Array: Initializer list must have either 1 or N elements.");
-    }
   }
 
   /// \brief Constructor to initialize all elements to a single value
   KOKKOS_INLINE_FUNCTION
-  constexpr Array(const T& value) : Array(value, std::make_index_sequence<N>{}) {
+  constexpr explicit Array(const T& value) : Array(value, std::make_index_sequence<N>{}) {
   }
 
   /// \brief Default destructor

--- a/mundy/core/math/src/mundy_math/Matrix.hpp
+++ b/mundy/core/math/src/mundy_math/Matrix.hpp
@@ -27,7 +27,6 @@
 // C++ core libs
 #include <cmath>
 #include <concepts>
-#include <initializer_list>
 #include <iostream>
 #include <type_traits>  // for std::decay_t
 #include <utility>
@@ -45,6 +44,7 @@
 #include <mundy_math/Scalar.hpp>          // for mundy::AScalar (interaction operators)
 #include <mundy_math/Vector.hpp>          // for mundy::Vector
 #include <mundy_math/impl/MatrixImpl.hpp>
+#include <mundy_math/impl/MatrixInverseImpl.hpp>
 #include <mundy_utils/requires.hpp>
 #include <mundy_utils/throw_assert.hpp>  // for MUNDY_THROW_ASSERT
 #include <mundy_math/cmath.hpp>
@@ -104,7 +104,7 @@ concept ValidMatrixType =
 ///
 /// \code{.cpp}
 ///   // Constructs an AMatrix with the default accessor (Array<int, 9>)
-///   AMatrix<int, 3, 3> mat1({1, 2, 3, 4, 5, 6, 7, 8, 9});
+///   AMatrix<int, 3, 3> mat1{1, 2, 3, 4, 5, 6, 7, 8, 9};
 ///   AMatrix<int, 3, 3> mat2(1, 2, 3, 4, 5, 6, 7, 8, 9);
 ///   AMatrix<int, 3, 3> mat3(Array<int, 9>{1, 2, 3, 4, 5, 6, 7, 8, 9});
 ///   AMatrix<int, 3, 3> mat4;
@@ -162,23 +162,20 @@ class AMatrix {
       : accessor_(accessor) {
   }
 
+  /// \brief Constructor to initialize all elements to a single value.
+  /// Only enabled if the Accessor has a 1-argument constructor.
+  KOKKOS_INLINE_FUNCTION constexpr explicit AMatrix(const T& value) MUNDY_REQUIRES(HasNArgConstructor<Accessor, T, 1>)
+      : accessor_(value) {
+  }
+
   /// \brief Constructor to initialize all elements explicitly.
   /// Requires the number of arguments to be N and the type of each to be T.
   /// Only enabled if the Accessor has a N-argument constructor.
   template <typename... Args>
-  MUNDY_REQUIRES((sizeof...(Args) == N * M) && (std::is_convertible_v<Args, T> && ...) &&
+  MUNDY_REQUIRES((sizeof...(Args) == N * M) && (N * M != 1) && (std::is_convertible_v<Args, T> && ...) &&
                  HasNArgConstructor<Accessor, T, N * M>)
-  KOKKOS_INLINE_FUNCTION explicit constexpr AMatrix(Args&&... args)
-      : accessor_(Accessor{static_cast<T>(std::forward<Args>(args))...}) {
-  }
-
-  /// \brief Constructor to initialize all elements via initializer list
-  /// \param[in] list The initializer list.
-  KOKKOS_INLINE_FUNCTION constexpr AMatrix(const std::initializer_list<T>& list)
-      MUNDY_REQUIRES(HasInitializerListConstructor<Accessor, T>)
-      : accessor_(list) {
-    MUNDY_THROW_ASSERT(list.size() == N * M, std::invalid_argument,
-                       "AMatrix: Initializer list must have N * M elements.");
+  KOKKOS_INLINE_FUNCTION constexpr AMatrix(Args&&... args)
+      : accessor_(Accessor(static_cast<T>(std::forward<Args>(args))...)) {
   }
 
   /// \brief Destructor
@@ -894,14 +891,6 @@ KOKKOS_INLINE_FUNCTION constexpr auto operator*(const AVector<U, N, Accessor1>& 
 //! \name Basic arithmetic reduction operations
 //@{
 
-/// \brief AMatrix determinant
-/// \param[in] mat The matrix.
-template <size_t N, size_t M, typename T, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION constexpr auto determinant(const AMatrix<T, N, M, Accessor>& mat) {
-  static_assert(N == M, "The determinant is only defined for square matrices.");
-  return impl::determinant_impl(std::make_index_sequence<N>{}, mat);
-}
-
 /// \brief AMatrix trace
 /// \param[in] mat The matrix.
 template <size_t N, size_t M, typename T, ValidAccessor<T> Accessor>
@@ -1008,39 +997,56 @@ KOKKOS_INLINE_FUNCTION constexpr AMatrix<T, M, N> transpose(const AMatrix<T, N, 
   return impl::transpose_impl(std::make_index_sequence<N * M>{}, mat);
 }
 
-/// \brief AMatrix cofactors
-/// \param[in] mat The matrix.
-template <size_t N, typename T, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<T, N, N> constexpr cofactors(const AMatrix<T, N, N, Accessor>& mat) {
-  return impl::cofactors_impl(std::make_index_sequence<N * N>{}, mat);
+/// \brief AMatrix determinant.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType = typename NumTraits<T>::NonInteger>
+KOKKOS_FORCEINLINE_FUNCTION constexpr OutputType determinant(const AMatrix<T, N, N, Accessor>& mat)
+  requires(N <= impl::kMatrixInverseLaplaceToLUCutoff)
+{
+  return static_cast<OutputType>(impl::bitmask_determinant(mat));
 }
 
-/// \brief AMatrix adjugate
-/// \param[in] mat The matrix.
+/// \brief AMatrix determinant.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType = typename NumTraits<T>::NonInteger>
+KOKKOS_FORCEINLINE_FUNCTION constexpr OutputType determinant(const AMatrix<T, N, N, Accessor>& mat)
+  requires(N > impl::kMatrixInverseLaplaceToLUCutoff)
+{
+  return impl::lu_determinant<N, T, Accessor, OutputType>(mat);
+}
+
+/// \brief AMatrix cofactors.
+/// \param[in] mat Source matrix.
 template <size_t N, typename T, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<T, N, N> constexpr adjugate(const AMatrix<T, N, N, Accessor>& mat) {
+KOKKOS_FORCEINLINE_FUNCTION constexpr Matrix<T, N, N> cofactors(const AMatrix<T, N, N, Accessor>& mat) {
+  return impl::bitmask_cofactors(mat);
+}
+
+/// \brief AMatrix adjugate.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor>
+KOKKOS_FORCEINLINE_FUNCTION constexpr Matrix<T, N, N> adjugate(const AMatrix<T, N, N, Accessor>& mat) {
   return transpose(cofactors(mat));
 }
 
-/// \briuf AMatrix inverse (returns a double if T is an integral type, otherwise returns T)
-/// \param[in] mat The matrix.
-template <size_t N, typename T, ValidAccessor<T> Accessor,
-          typename OutputType = typename NumTraits<T>::NonInteger>
-KOKKOS_INLINE_FUNCTION AMatrix<OutputType, N, N> constexpr inverse(const AMatrix<T, N, N, Accessor>& mat) {
-  const auto det = determinant(mat);
-  MUNDY_THROW_ASSERT(det != T(0), std::runtime_error, "AMatrix<T>: matrix is singular.");
+/// \brief AMatrix inverse.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType = typename NumTraits<T>::NonInteger>
+KOKKOS_FORCEINLINE_FUNCTION constexpr Matrix<OutputType, N, N> inverse(const AMatrix<T, N, N, Accessor>& mat)
+  requires(N <= impl::kMatrixInverseLaplaceToLUCutoff)
+{
+  const auto det = impl::bitmask_determinant(mat);
+  MUNDY_THROW_ASSERT(det != T(0), std::runtime_error, "inverse: matrix is singular.");
   return adjugate(mat).template cast<OutputType>() / det;
 }
 
-/// \brief AMatrix inverse (returns a float if T is an integral type, otherwise returns T)
-/// \tparam T The input matrix element type.
-/// \tparam Accessor The accessor for the AMatrix, assuming this is part of your implementation.
-/// \tparam OutputElementType The output matrix element type, defaults T if T is an integral type (e.g., float or
-/// double) and float otherwise.
-template <size_t N, typename T, ValidAccessor<T> Accessor,
-          typename OutputElementType = std::conditional_t<NumTraits<T>::IsInteger, float, T>>
-KOKKOS_INLINE_FUNCTION constexpr auto inverse_f(const AMatrix<T, N, N, Accessor>& mat) {
-  return inverse(mat);
+/// \brief AMatrix inverse.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType = typename NumTraits<T>::NonInteger>
+KOKKOS_FORCEINLINE_FUNCTION constexpr Matrix<OutputType, N, N> inverse(const AMatrix<T, N, N, Accessor>& mat)
+  requires(N > impl::kMatrixInverseLaplaceToLUCutoff)
+{
+  return impl::lu_inverse<N, T, Accessor, OutputType>(mat);
 }
 
 /// \brief AMatrix Frobenius inner product

--- a/mundy/core/math/src/mundy_math/Quaternion.hpp
+++ b/mundy/core/math/src/mundy_math/Quaternion.hpp
@@ -25,8 +25,7 @@
 #include <Kokkos_Core.hpp>
 
 // C++ core
-#include <initializer_list>  // for std::initializer_list
-#include <type_traits>       // for std::decay_t
+#include <type_traits>  // for std::decay_t
 #include <utility>
 
 // Mundy
@@ -166,20 +165,8 @@ class AQuaternion {
  private:
   KOKKOS_INLINE_FUNCTION
   static constexpr Accessor make_storage_from_semantic_components(const T& w, const T& x, const T& y, const T& z)
-      MUNDY_REQUIRES(HasNArgConstructor<Accessor, T, 4> || HasInitializerListConstructor<Accessor, T>) {
-    return Accessor{x, y, z, w};
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static constexpr Accessor make_storage_from_semantic_components(const std::initializer_list<T>& list)
-      MUNDY_REQUIRES(HasInitializerListConstructor<Accessor, T>) {
-    MUNDY_THROW_ASSERT(list.size() == 4, std::invalid_argument, "AQuaternion: Initializer list must have 4 elements.");
-    auto it = list.begin();
-    const T w = *it++;
-    const T x = *it++;
-    const T y = *it++;
-    const T z = *it++;
-    return make_storage_from_semantic_components(w, x, y, z);
+      MUNDY_REQUIRES(HasNArgConstructor<Accessor, T, 4>) {
+    return Accessor(x, y, z, w);
   }
 
  public:
@@ -208,14 +195,6 @@ class AQuaternion {
   KOKKOS_INLINE_FUNCTION constexpr AQuaternion(const T& w, const T& x, const T& y, const T& z)
       MUNDY_REQUIRES(HasNArgConstructor<Accessor, T, 4>)
       : accessor_(make_storage_from_semantic_components(w, x, y, z)) {
-  }
-
-  /// \brief Constructor to initialize all elements via initializer list
-  /// \param[in] list The initializer list.
-  /// \note The initializer list is interpreted in `(w, x, y, z)` order.
-  KOKKOS_INLINE_FUNCTION constexpr AQuaternion(const std::initializer_list<T>& list)
-      MUNDY_REQUIRES(HasInitializerListConstructor<Accessor, T>)
-      : accessor_(make_storage_from_semantic_components(list)) {
   }
 
   /// \brief Destructor
@@ -405,7 +384,7 @@ class AQuaternion {
   /// \brief Cast (and copy) the quaternion to a different type
   template <typename U>
   KOKKOS_INLINE_FUNCTION constexpr auto cast() const {
-    return AQuaternion<U>{static_cast<U>(w()), static_cast<U>(x()), static_cast<U>(y()), static_cast<U>(z())};
+    return AQuaternion<U>(static_cast<U>(w()), static_cast<U>(x()), static_cast<U>(y()), static_cast<U>(z()));
   }
   //@}
 

--- a/mundy/core/math/src/mundy_math/Vector.hpp
+++ b/mundy/core/math/src/mundy_math/Vector.hpp
@@ -27,7 +27,6 @@
 // C++ core
 #include <cmath>
 #include <concepts>
-#include <initializer_list>
 #include <iostream>
 #include <type_traits>  // for std::decay_t
 #include <utility>
@@ -175,15 +174,8 @@ class AVector {
   template <typename... Args>
   MUNDY_REQUIRES((sizeof...(Args) == N) && (N != 1) && (std::is_convertible_v<Args, T> && ...) &&
                  HasNArgConstructor<Accessor, T, N>)
-  KOKKOS_INLINE_FUNCTION constexpr explicit AVector(Args&&... args)
-      : accessor_(Accessor{static_cast<T>(std::forward<Args>(args))...}) {
-  }
-
-  /// \brief Constructor to initialize all elements via initializer list
-  /// \param[in] list The initializer list.
-  KOKKOS_INLINE_FUNCTION constexpr AVector(const std::initializer_list<T>& list)
-      MUNDY_REQUIRES(HasInitializerListConstructor<Accessor, T>)
-      : accessor_(list) {
+  KOKKOS_INLINE_FUNCTION constexpr AVector(Args&&... args)
+      : accessor_(Accessor(static_cast<T>(std::forward<Args>(args))...)) {
   }
 
   /// \brief Destructor

--- a/mundy/core/math/src/mundy_math/cmath.hpp
+++ b/mundy/core/math/src/mundy_math/cmath.hpp
@@ -33,6 +33,7 @@
 
 // C++ core
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 
 namespace mundy {
@@ -110,8 +111,6 @@ MUNDY_MATH_DISPATCH_UNARY(atan)
 MUNDY_MATH_DISPATCH_UNARY(exp)
 MUNDY_MATH_DISPATCH_UNARY(log)
 MUNDY_MATH_DISPATCH_UNARY(log10)
-MUNDY_MATH_DISPATCH_UNARY(abs)
-MUNDY_MATH_DISPATCH_UNARY(fabs)
 MUNDY_MATH_DISPATCH_UNARY(floor)
 MUNDY_MATH_DISPATCH_UNARY(ceil)
 MUNDY_MATH_DISPATCH_UNARY(round)
@@ -124,6 +123,52 @@ MUNDY_MATH_DISPATCH_BINARY(max)
 
 #undef MUNDY_MATH_DISPATCH_UNARY
 #undef MUNDY_MATH_DISPATCH_BINARY
+
+/// \brief Reinterprets the bits of From as To.
+///
+/// On the host, we can simply call std::bit_cast, but on the device we directly call __builtin_bit_cast, which is constexpr
+/// and used by both CUDA and STD to perform their bit cast. Compiler support for __builtin_bit_cast is checked with __has_builtin,
+/// and a fallback implementation that just calls Kokkos::bit_cast is provided if it doesn't exist.
+///
+/// \param[in] from Value whose bit pattern is reinterpreted.
+template <typename To, typename From>
+KOKKOS_INLINE_FUNCTION constexpr To bit_cast(const From& from) {
+  static_assert(sizeof(To) == sizeof(From), "bit_cast requires equal-size types.");
+  static_assert(std::is_trivially_copyable_v<To> && std::is_trivially_copyable_v<From>,
+               "bit_cast requires trivially copyable types.");
+#if defined(__has_builtin) && __has_builtin(__builtin_bit_cast)
+  return __builtin_bit_cast(To, from);
+#else
+  return Kokkos::bit_cast<To>(from);
+#endif
+}
+
+/// \brief Absolute value (constexpr-compatible for arithmetic types, ADL for others).
+///
+/// Kokkos::abs is not constexpr. For float/double, clearing the sign bit via bit_cast sidesteps the problem entirely.
+/// Other arithmetic types fall back to a plain comparison; non-arithmetic (AD) types use ADL, matching the other dispatch functions above.
+///
+/// \param[in] x Value to take the absolute value of.
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr auto abs(const T& x) {
+  if constexpr (std::is_same_v<T, double>) {
+    return bit_cast<double>(static_cast<std::uint64_t>(bit_cast<std::uint64_t>(x) & 0x7FFF'FFFF'FFFF'FFFFULL));
+  } else if constexpr (std::is_same_v<T, float>) {
+    return bit_cast<float>(static_cast<std::uint32_t>(bit_cast<std::uint32_t>(x) & 0x7FFF'FFFFU));
+  } else if constexpr (std::is_arithmetic_v<T>) {
+    return x < T(0) ? -x : x;
+  } else {
+    using std::abs;
+    return abs(x);
+  }
+}
+
+/// \brief Absolute value of a floating-point argument. Equivalent to abs() here.
+/// \param[in] x Value to take the absolute value of.
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr auto fabs(const T& x) {
+  return abs(x);
+}
 
 namespace impl {
 

--- a/mundy/core/math/src/mundy_math/convex.hpp
+++ b/mundy/core/math/src/mundy_math/convex.hpp
@@ -367,7 +367,6 @@ class QuadraticFormOp {
   KOKKOS_INLINE_FUNCTION const auto& DT() const { return impl::unwrap(DT_storage_); }
   KOKKOS_INLINE_FUNCTION const auto& M() const { return impl::unwrap(M_storage_); }
   KOKKOS_INLINE_FUNCTION const auto& D() const { return impl::unwrap(D_storage_); }
-  KOKKOS_INLINE_FUNCTION
   // clang-format on
 
   size_t domain_size() const {
@@ -404,7 +403,7 @@ class QuadraticFormOp {
   }
 
   template <class XVector, class YVector, class WorkspaceType>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
     impl::workspace_invalidate(workspace);
     Backend::apply(impl::unwrap(D_storage_), x, workspace.f());
     Backend::apply(impl::unwrap(M_storage_), workspace.f(), workspace.u());
@@ -412,7 +411,7 @@ class QuadraticFormOp {
   }
 
   template <class XVector, class YVector, class WorkspaceType>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y) const {
     auto tmp_workspace = make_workspace();
     apply(x, y, tmp_workspace);
   }
@@ -455,19 +454,19 @@ class MixedReducedOp {
     KOKKOS_INLINE_FUNCTION const auto& l_workspace() const { return impl::unwrap(l_workspace_storage_); }
     // clang-format on
 
-    KOKKOS_INLINE_FUNCTION void commit() {
+    KOKKOS_FUNCTION void commit() {
       committed_ = true;
       impl::workspace_commit(a_workspace());
       impl::workspace_commit(l_workspace());
     }
 
-    KOKKOS_INLINE_FUNCTION void invalidate() {
+    KOKKOS_FUNCTION void invalidate() {
       committed_ = false;
       impl::workspace_invalidate(a_workspace());
       impl::workspace_invalidate(l_workspace());
     }
 
-    KOKKOS_INLINE_FUNCTION bool is_committed() const {
+    KOKKOS_FUNCTION bool is_committed() const {
       return committed_ && impl::workspace_is_committed(a_workspace()) && impl::workspace_is_committed(l_workspace());
     }
 
@@ -488,7 +487,6 @@ class MixedReducedOp {
   KOKKOS_INLINE_FUNCTION Backend backend() const { return Backend{}; }
   KOKKOS_INLINE_FUNCTION const auto& A() const { return impl::unwrap(A_storage_); }
   KOKKOS_INLINE_FUNCTION const auto& L() const { return impl::unwrap(L_storage_); }
-  KOKKOS_INLINE_FUNCTION
   // clang-format on
 
   size_t domain_size() const {
@@ -540,7 +538,7 @@ class MixedReducedOp {
   }
 
   template <class XVector, class YVector, class WorkspaceType>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
     impl::workspace_invalidate(workspace);
     constexpr auto one = static_cast<impl::vector_value_type<XVector>>(1);
     // workspace.ax = A x
@@ -557,7 +555,7 @@ class MixedReducedOp {
   }
 
   template <class XVector, class YVector, class WorkspaceType>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y) const {
     auto tmp_workspace = make_workspace();
     apply(x, y, tmp_workspace);
   }
@@ -613,7 +611,7 @@ class CongruentMixedReducedOp {
     KOKKOS_INLINE_FUNCTION const auto& l_workspace() const { return impl::unwrap(l_workspace_storage_); }
     // clang-format on
 
-    KOKKOS_INLINE_FUNCTION void commit() {
+    KOKKOS_FUNCTION void commit() {
       committed_ = true;
       impl::workspace_commit(dt_workspace());
       impl::workspace_commit(m_workspace());
@@ -621,7 +619,7 @@ class CongruentMixedReducedOp {
       impl::workspace_commit(l_workspace());
     }
 
-    KOKKOS_INLINE_FUNCTION void invalidate() {
+    KOKKOS_FUNCTION void invalidate() {
       committed_ = false;
       impl::workspace_invalidate(dt_workspace());
       impl::workspace_invalidate(m_workspace());
@@ -629,7 +627,7 @@ class CongruentMixedReducedOp {
       impl::workspace_invalidate(l_workspace());
     }
 
-    KOKKOS_INLINE_FUNCTION bool is_committed() const {
+    KOKKOS_FUNCTION bool is_committed() const {
       return committed_ && impl::workspace_is_committed(dt_workspace()) &&
              impl::workspace_is_committed(m_workspace()) && impl::workspace_is_committed(d_workspace()) &&
              impl::workspace_is_committed(l_workspace());
@@ -662,7 +660,6 @@ class CongruentMixedReducedOp {
   KOKKOS_INLINE_FUNCTION const auto& M() const { return impl::unwrap(M_storage_); }
   KOKKOS_INLINE_FUNCTION const auto& D() const { return impl::unwrap(D_storage_); }
   KOKKOS_INLINE_FUNCTION const auto& L() const { return impl::unwrap(L_storage_); }
-  KOKKOS_INLINE_FUNCTION
   // clang-format on
 
   size_t domain_size() const {
@@ -732,7 +729,7 @@ class CongruentMixedReducedOp {
   }
 
   template <class XVector, class YVector, class WorkspaceType>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y, WorkspaceType& workspace) const {
     impl::workspace_invalidate(workspace);
     constexpr auto one = static_cast<impl::vector_value_type<XVector>>(1);
     Backend::apply(D(), x, workspace.dx(), workspace.d_workspace());
@@ -744,7 +741,7 @@ class CongruentMixedReducedOp {
   }
 
   template <class XVector, class YVector>
-  KOKKOS_INLINE_FUNCTION void apply(const XVector& x, YVector& y) const {
+  KOKKOS_FUNCTION void apply(const XVector& x, YVector& y) const {
     auto tmp_workspace = make_workspace();
     apply(x, y, tmp_workspace);
   }
@@ -766,7 +763,9 @@ struct KokkosBackend {
   template <class Vector>
   static auto make_vector_like(const Vector& q) {
     return Vector(
-        q.extent(0));  // assumes Vector has a constructor that takes a size, and that the size is given by extent(0)
+        "make_vector_like",
+        q.extent(0));  // Kokkos::View has no label-less allocating ctor; a size alone resolves to
+                       // the (incompatible) pointer-wrapping overload instead.
   }
 
   // make_domain/range_vector is host only, but may be called from KOKKOS_FUNCTION code being called on the host
@@ -1480,7 +1479,7 @@ class LCPProblem {
 };
 
 template <class Backend, class LinearOp, class QVectorStorage>
-KOKKOS_INLINE_FUNCTION auto to_cqpp(const LCPProblem<Backend, LinearOp, QVectorStorage>& P) {
+KOKKOS_FUNCTION auto to_cqpp(const LCPProblem<Backend, LinearOp, QVectorStorage>& P) {
   using value_type = typename LCPProblem<Backend, LinearOp, QVectorStorage>::value_type;
   static constexpr space::LowerBound Rn_plus{static_cast<value_type>(0)};
   return CQPPProblem(P.backend(), P.A(), P.q(), Rn_plus, P.workspace());
@@ -1488,8 +1487,8 @@ KOKKOS_INLINE_FUNCTION auto to_cqpp(const LCPProblem<Backend, LinearOp, QVectorS
 
 template <class Backend, class LinearOpAStorage, class QVectorStorage, class LinearOpLStorage, class FVectorStorage,
           class ConvexSpace, class AWorkspace, class LWorkspace>
-KOKKOS_INLINE_FUNCTION auto to_cqpp(const MCQPPProblem<Backend, LinearOpAStorage, QVectorStorage, LinearOpLStorage,
-                                                       FVectorStorage, ConvexSpace, AWorkspace, LWorkspace>& P) {
+KOKKOS_FUNCTION auto to_cqpp(const MCQPPProblem<Backend, LinearOpAStorage, QVectorStorage, LinearOpLStorage,
+                                                FVectorStorage, ConvexSpace, AWorkspace, LWorkspace>& P) {
   // get the type of P no ref
   using value_type = std::remove_reference_t<decltype(P)>::value_type;
 
@@ -1516,7 +1515,7 @@ KOKKOS_INLINE_FUNCTION auto to_cqpp(const MCQPPProblem<Backend, LinearOpAStorage
 template <class Backend, class LinearOpDTStorage, class LinearOpMStorage, class LinearOpDStorage, class QVectorStorage,
           class LinearOpLStorage, class FVectorStorage, class ConvexSpace, class DTWorkspace, class MWorkspace,
           class DWorkspace, class LWorkspace>
-KOKKOS_INLINE_FUNCTION auto to_cqpp(
+KOKKOS_FUNCTION auto to_cqpp(
     const CongruentMCQPPProblem<Backend, LinearOpDTStorage, LinearOpMStorage, LinearOpDStorage, QVectorStorage,
                                 LinearOpLStorage, FVectorStorage, ConvexSpace, DTWorkspace, MWorkspace, DWorkspace,
                                 LWorkspace>& P) {
@@ -1561,10 +1560,10 @@ KOKKOS_INLINE_FUNCTION auto to_cqpp(
 struct LinfNormProjectedGradientResidual {  // Lower bound only for non-negativity constraints
   template <typename Backend, typename XVector, typename GradVector,
             typename ReductionScalar = impl::vector_value_type<GradVector>>
-  KOKKOS_INLINE_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
-                                                    const XVector& x,                         //
-                                                    const GradVector& grad,                   //
-                                                    const space::LowerBound<ReductionScalar>& convex_space) const {
+  KOKKOS_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
+                                             const XVector& x,                         //
+                                             const GradVector& grad,                   //
+                                             const space::LowerBound<ReductionScalar>& convex_space) const {
     MUNDY_THROW_REQUIRE(convex_space.bound() == static_cast<ReductionScalar>(0), std::invalid_argument,
                         "LinfNormProjectedGradientResidual is only implemented for non-negativity constraints.");
 
@@ -1599,10 +1598,10 @@ struct LinfNormProjectedGradientResidual {  // Lower bound only for non-negativi
 struct LinfNormProjectedDiffResidual {
   template <typename Backend, typename XVector, typename GradVector, space::ValidConvexSpace ConvexSpace,
             typename ReductionScalar = impl::vector_value_type<GradVector>>
-  KOKKOS_INLINE_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
-                                                    const XVector& x,                         //
-                                                    const GradVector& grad,                   //
-                                                    const ConvexSpace& convex_space) const {
+  KOKKOS_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
+                                             const XVector& x,                         //
+                                             const GradVector& grad,                   //
+                                             const ConvexSpace& convex_space) const {
     using value_type = ReductionScalar;
 
     // This res comes from line 17 and Eq 25 of Mazhar 2015
@@ -1630,10 +1629,10 @@ struct LinfNormProjectedDiffResidual {
 struct BBStepStrategy {
   template <typename Backend, typename XOldVector, typename GradOldVector, typename XVector, typename GradVector,
             typename ReductionScalar = impl::vector_value_type<XVector>>
-  KOKKOS_INLINE_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
-                                                    const XOldVector& x_old,
-                                                    const GradOldVector& grad_old,  //
-                                                    const XVector& x, const GradVector& grad) const {
+  KOKKOS_FUNCTION ReductionScalar operator()([[maybe_unused]] const Backend& backend,  //
+                                             const XOldVector& x_old,
+                                             const GradOldVector& grad_old,  //
+                                             const XVector& x, const GradVector& grad) const {
     using value_type = ReductionScalar;
 
     value_type num = Backend::template diff_dot<value_type>(x, x_old);  // (x - x_old) dot (x - x_old)
@@ -1739,7 +1738,7 @@ class PGDStrategy {
   }
 
   template <class Problem, class State>
-  KOKKOS_INLINE_FUNCTION void initialize(const Problem& prob, State& state) const {
+  KOKKOS_FUNCTION void initialize(const Problem& prob, State& state) const {
     auto backend = prob.backend();
     using backend_t = decltype(backend);
 
@@ -1771,7 +1770,7 @@ class PGDStrategy {
   }
 
   template <class Problem, class State>
-  KOKKOS_INLINE_FUNCTION bool iterate(const Problem& prob, State& state) const {
+  KOKKOS_FUNCTION bool iterate(const Problem& prob, State& state) const {
     auto backend = prob.backend();
     using backend_t = decltype(backend);
 
@@ -1807,12 +1806,12 @@ class PGDStrategy {
   }
 
   template <class State>
-  KOKKOS_INLINE_FUNCTION bool done(const State& state) const {
+  KOKKOS_FUNCTION bool done(const State& state) const {
     return state.converged() || state.iter() >= cfg_.max_iters;
   }
 
   template <class State>
-  KOKKOS_INLINE_FUNCTION result_t result(const State& state) const {
+  KOKKOS_FUNCTION result_t result(const State& state) const {
     return {state.iter(), state.residual(), state.converged()};
   }
 
@@ -2039,8 +2038,8 @@ KOKKOS_INLINE_FUNCTION auto make_mixed_cqpp(LinearOpDT&& DT, LinearOpM&& M, Line
 template <typename Backend, typename LinearOpDT, typename LinearOpM, typename LinearOpD, typename QVector,
           typename LinearOpB, typename LinearOpS, typename LinearOpBT, typename BVector,
           convex::space::ValidConvexSpace ConvexSpace>
-KOKKOS_INLINE_FUNCTION auto make_mixed_cqpp(LinearOpDT&& DT, LinearOpM&& M, LinearOpD&& D, QVector&& q, LinearOpB&& B,
-                                            LinearOpS&& S, LinearOpBT&& BT, BVector&& b, ConvexSpace&& space) {
+KOKKOS_FUNCTION auto make_mixed_cqpp(LinearOpDT&& DT, LinearOpM&& M, LinearOpD&& D, QVector&& q, LinearOpB&& B,
+                                     LinearOpS&& S, LinearOpBT&& BT, BVector&& b, ConvexSpace&& space) {
   auto DT_storage = convex::impl::to_storage(std::forward<LinearOpDT>(DT));
   auto M_storage = convex::impl::to_storage(std::forward<LinearOpM>(M));
   auto D_storage = convex::impl::to_storage(std::forward<LinearOpD>(D));
@@ -2105,7 +2104,7 @@ KOKKOS_INLINE_FUNCTION auto make_pgd_state(XVector&& x,         //
 /// \return The result of the solve (contents are defined by the strategy).
 template <class Problem, class Strategy, class State>
 MUNDY_REQUIRES(convex::CQPPSolverStrategy<Strategy, Problem, State>)
-KOKKOS_INLINE_FUNCTION auto solve_cqpp(const Problem& prob, const Strategy& strat, State& state) {
+KOKKOS_FUNCTION auto solve_cqpp(const Problem& prob, const Strategy& strat, State& state) {
   strat.initialize(prob, state);
   while (!strat.done(state)) {
     if (strat.iterate(prob, state)) break;
@@ -2157,13 +2156,11 @@ KOKKOS_INLINE_FUNCTION auto solve_cqpp(const Problem& prob, const Strategy& stra
 /// \param strat The solution strategy to use (for the reduced CQPP in x and the linear solve in y).
 /// \param state The state to use for the solution strategy, which will be modified during the solve.
 /// \return The result of the solve (contents are defined by the strategy).
-template <class Problem, class Strategy>
+template <class Problem, class Strategy, class State>
 MUNDY_REQUIRES(requires(const Problem& p) {
   { to_cqpp(p) };
 })
-KOKKOS_INLINE_FUNCTION
-    auto solve_mixed_cqpp(const Problem& prob, const Strategy& strat, typename Strategy::state_t& state) ->
-    typename Strategy::result_t {
+KOKKOS_FUNCTION auto solve_mixed_cqpp(const Problem& prob, const Strategy& strat, State& state) {
   // Convert MCQPP to CQPP
   auto ccpp_prob = to_cqpp(prob);
   return solve_cqpp(ccpp_prob, strat, state);
@@ -2242,7 +2239,7 @@ template <class Problem, class Strategy, class State>
 MUNDY_REQUIRES(requires(const Problem& p) {
   { to_cqpp(p) };
 })
-KOKKOS_INLINE_FUNCTION auto solve_lcp(const Problem& prob, const Strategy& strat, State& state) {
+KOKKOS_FUNCTION auto solve_lcp(const Problem& prob, const Strategy& strat, State& state) {
   // Convert LCP to CQPP
   auto ccpp_prob = to_cqpp(prob);
   return solve_cqpp(ccpp_prob, strat, state);

--- a/mundy/core/math/src/mundy_math/impl/AccessorImpl.hpp
+++ b/mundy/core/math/src/mundy_math/impl/AccessorImpl.hpp
@@ -30,13 +30,13 @@ namespace impl {
 
 // Helper for generating a tuple with T repeated N times
 template <typename T, size_t... Is>
-auto generate_tuple_with_t_repeated_impl(std::index_sequence<Is...>) {
+constexpr auto generate_tuple_with_t_repeated_impl(std::index_sequence<Is...>) {
   return std::tuple<std::conditional_t<true, T, decltype(Is)>...>{};
 }
 
 // Main template to generate a tuple with T repeated N times
 template <typename T, size_t N>
-auto generate_tuple_with_t_repeated_n_times() {
+constexpr auto generate_tuple_with_t_repeated_n_times() {
   return generate_tuple_with_t_repeated_impl<T>(std::make_index_sequence<N>{});
 }
 

--- a/mundy/core/math/src/mundy_math/impl/MatrixImpl.hpp
+++ b/mundy/core/math/src/mundy_math/impl/MatrixImpl.hpp
@@ -55,6 +55,7 @@ MUNDY_REQUIRES(ValidScalarType<T>)
 class AMatrix;
 
 namespace impl {
+
 //! \name Helper functions for generic matrix operators applied to an abstract accessor.
 //@{
 
@@ -63,7 +64,7 @@ namespace impl {
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U,
           ValidAccessor<U> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>&& std::is_convertible_v<U, T>)
-KOKKOS_INLINE_FUNCTION void deep_copy_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void deep_copy_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
                                            const AMatrix<U, N, M, OtherAccessor>& other) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] = static_cast<T>(other[Is])), ...);
@@ -73,7 +74,7 @@ KOKKOS_INLINE_FUNCTION void deep_copy_impl(std::index_sequence<Is...>, AMatrix<T
 /// \details Moves the data from the other matrix to our data. This is only enabled if T is not const.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, ValidAccessor<T> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void move_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void move_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
                                       AMatrix<T, N, M, OtherAccessor>&& other) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] = std::move(other[Is])), ...);
@@ -82,7 +83,7 @@ KOKKOS_INLINE_FUNCTION void move_impl(std::index_sequence<Is...>, AMatrix<T, N, 
 /// \brief Get a deep copy of a certain column of the matrix
 /// \param[in] col The column index.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AVector<std::remove_const_t<T>, N> copy_column_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr AVector<std::remove_const_t<T>, N> copy_column_impl(std::index_sequence<Is...>,
                                                                            const AMatrix<T, N, M, Accessor>& mat,
                                                                            size_t col) {
   static_assert(sizeof...(Is) == N, "Number of indices must match number of rows.");
@@ -92,7 +93,7 @@ KOKKOS_INLINE_FUNCTION AVector<std::remove_const_t<T>, N> copy_column_impl(std::
 /// \brief Get a deep copy of a certain row of the matrix
 /// \param[in] row The row index.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AVector<std::remove_const_t<T>, M> copy_row_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr AVector<std::remove_const_t<T>, M> copy_row_impl(std::index_sequence<Is...>,
                                                                         const AMatrix<T, N, M, Accessor>& mat,
                                                                         size_t row) {
   static_assert(sizeof...(Is) == M, "Number of indices must match number of columns.");
@@ -115,15 +116,15 @@ KOKKOS_INLINE_FUNCTION static constexpr Kokkos::Array<bool, N * M> create_row_an
 
 /// \brief Cast (and copy) the matrix to a different type
 template <typename U, size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<U, N, M> cast_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr AMatrix<U, N, M> cast_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
-  return AMatrix<U, N, M>{static_cast<U>(mat[Is])...};
+  return AMatrix<U, N, M>(static_cast<U>(mat[Is])...);
 }
 
 /// \brief Set all elements of the matrix
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename... Args>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void set_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, Args&&... args) {
+KOKKOS_INLINE_FUNCTION constexpr void set_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, Args&&... args) {
   static_assert(sizeof...(Is) == N * M, "Number of arguments must match number of elements in the matrix.");
   ((mat[Is] = std::forward<Args>(args)), ...);
 }
@@ -134,7 +135,7 @@ KOKKOS_INLINE_FUNCTION void set_impl(std::index_sequence<Is...>, AMatrix<T, N, M
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
 KOKKOS_INLINE_FUNCTION
-    void set_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const auto& accessor) {
+    constexpr void set_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const auto& accessor) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] = accessor[Is]), ...);
 }
@@ -144,7 +145,7 @@ KOKKOS_INLINE_FUNCTION
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename... Args>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
 KOKKOS_INLINE_FUNCTION
-    void set_row_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& i, Args&&... args) {
+    constexpr void set_row_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& i, Args&&... args) {
   static_assert(sizeof...(Is) == M, "Number of arguments must match number of columns.");
   ((mat(i, Is) = std::forward<Args>(args)), ...);
 }
@@ -154,7 +155,7 @@ KOKKOS_INLINE_FUNCTION
 /// \param[in] row The row vector.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, ValidAccessor<T> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void set_row_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& i,
+KOKKOS_INLINE_FUNCTION constexpr void set_row_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& i,
                                          const AVector<T, M, OtherAccessor>& row) {
   static_assert(sizeof...(Is) == M, "Number of arguments must match number of columns.");
   ((mat(i, Is) = row[Is]), ...);
@@ -165,7 +166,7 @@ KOKKOS_INLINE_FUNCTION void set_row_impl(std::index_sequence<Is...>, AMatrix<T, 
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename... Args>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
 KOKKOS_INLINE_FUNCTION
-    void set_column_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& j, Args&&... args) {
+    constexpr void set_column_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const size_t& j, Args&&... args) {
   static_assert(sizeof...(Is) == N, "Number of arguments must match number of rows.");
   ((mat(Is, j) = std::forward<Args>(args)), ...);
 }
@@ -175,7 +176,7 @@ KOKKOS_INLINE_FUNCTION
 /// \param[in] col The column vector.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, ValidAccessor<T> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void set_column_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void set_column_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
                                             const size_t& j, const AVector<T, N, OtherAccessor>& col) {
   static_assert(sizeof...(Is) == N, "Number of arguments must match number of rows.");
   ((mat(Is, j) = col[Is]), ...);
@@ -185,14 +186,14 @@ KOKKOS_INLINE_FUNCTION void set_column_impl(std::index_sequence<Is...>, AMatrix<
 /// \param[in] value The value to set all elements to.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void fill_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const T& value) {
+KOKKOS_INLINE_FUNCTION constexpr void fill_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const T& value) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] = value), ...);
 }
 
 /// \brief Unary minus operator
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<T, N, M> unary_minus_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr AMatrix<T, N, M> unary_minus_impl(std::index_sequence<Is...>,
                                                          const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   AMatrix<T, N, M> result;
@@ -204,7 +205,7 @@ KOKKOS_INLINE_FUNCTION AMatrix<T, N, M> unary_minus_impl(std::index_sequence<Is.
 /// \param[in] other The other matrix.
 template <size_t... Is, typename T, size_t N, size_t M, typename U, ValidAccessor<T> Accessor,
           ValidAccessor<U> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto matrix_matrix_addition_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_matrix_addition_impl(std::index_sequence<Is...>,
                                                         const AMatrix<T, N, M, Accessor>& mat,
                                                         const AMatrix<U, N, M, OtherAccessor>& other)
     -> AMatrix<scalar_sum_result_t<T, U>, N, M> {
@@ -220,7 +221,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_matrix_addition_impl(std::index_sequence<Is..
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U,
           ValidAccessor<U> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void self_matrix_addition_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void self_matrix_addition_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
                                                       const AMatrix<U, N, M, OtherAccessor>& other)
     MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
@@ -231,7 +232,7 @@ KOKKOS_INLINE_FUNCTION void self_matrix_addition_impl(std::index_sequence<Is...>
 /// \param[in] other The other matrix.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U,
           ValidAccessor<U> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto matrix_matrix_subtraction_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_matrix_subtraction_impl(std::index_sequence<Is...>,
                                                            const AMatrix<T, N, M, Accessor>& mat,
                                                            const AMatrix<U, N, M, OtherAccessor>& other)
     -> AMatrix<scalar_difference_result_t<T, U>, N, M> {
@@ -247,7 +248,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_matrix_subtraction_impl(std::index_sequence<I
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U,
           ValidAccessor<U> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void self_matrix_subtraction_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void self_matrix_subtraction_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat,
                                                          const AMatrix<U, N, M, OtherAccessor>& other)
     MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
@@ -259,7 +260,7 @@ KOKKOS_INLINE_FUNCTION void self_matrix_subtraction_impl(std::index_sequence<Is.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    auto matrix_scalar_addition_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
+    constexpr auto matrix_scalar_addition_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
         -> AMatrix<scalar_sum_result_t<T, U>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   using CommonType = scalar_sum_result_t<T, U>;
@@ -273,7 +274,7 @@ KOKKOS_INLINE_FUNCTION
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>&& ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    void self_scalar_addition_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
+    constexpr void self_scalar_addition_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] += static_cast<T>(scalar)), ...);
 }
@@ -282,7 +283,7 @@ KOKKOS_INLINE_FUNCTION
 /// \param[in] scalar The scalar.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(ValidScalarType<U>)
-KOKKOS_INLINE_FUNCTION auto matrix_scalar_subtraction_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_scalar_subtraction_impl(std::index_sequence<Is...>,
                                                            const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
     -> AMatrix<scalar_difference_result_t<T, U>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
@@ -297,7 +298,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_scalar_subtraction_impl(std::index_sequence<I
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>&& ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    void self_scalar_subtraction_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
+    constexpr void self_scalar_subtraction_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] -= static_cast<T>(scalar)), ...);
 }
@@ -306,7 +307,7 @@ KOKKOS_INLINE_FUNCTION
 /// \param[in] other The other matrix.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U, size_t OtherN,
           size_t OtherM, ValidAccessor<U> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto matrix_matrix_multiplication_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_matrix_multiplication_impl(std::index_sequence<Is...>,
                                                               const AMatrix<T, N, M, Accessor>& mat,
                                                               const AMatrix<U, OtherN, OtherM, OtherAccessor>& other)
     -> AMatrix<scalar_product_result_t<T, U>, N, OtherM> {
@@ -327,7 +328,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_matrix_multiplication_impl(std::index_sequenc
 /// \param[in] other The other matrix.
 template <size_t... Is, typename T, size_t N, ValidAccessor<T> Accessor, typename U, ValidAccessor<U> OtherAccessor>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>)
-KOKKOS_INLINE_FUNCTION void self_matrix_multiplication_impl(std::index_sequence<Is...>, AMatrix<T, N, N, Accessor>& mat,
+KOKKOS_INLINE_FUNCTION constexpr void self_matrix_multiplication_impl(std::index_sequence<Is...>, AMatrix<T, N, N, Accessor>& mat,
                                                             const AMatrix<U, N, N, OtherAccessor>& other)
     MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>) {
   static_assert(sizeof...(Is) == N * N, "Number of indices must match number of elements in the matrix.");
@@ -342,7 +343,7 @@ KOKKOS_INLINE_FUNCTION void self_matrix_multiplication_impl(std::index_sequence<
 /// \param[in] other The other vector.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U,
           ValidAccessor<U> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto matrix_vector_multiplication_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_vector_multiplication_impl(std::index_sequence<Is...>,
                                                               const AMatrix<T, N, M, Accessor>& mat,
                                                               const AVector<U, M, OtherAccessor>& other)
     -> AVector<scalar_product_result_t<T, U>, N> {
@@ -361,7 +362,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_vector_multiplication_impl(std::index_sequenc
 /// \param[in] scalar The scalar.
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(ValidScalarType<U>)
-KOKKOS_INLINE_FUNCTION auto matrix_scalar_multiplication_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto matrix_scalar_multiplication_impl(std::index_sequence<Is...>,
                                                               const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
     -> AMatrix<scalar_product_result_t<T, U>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
@@ -376,7 +377,7 @@ KOKKOS_INLINE_FUNCTION auto matrix_scalar_multiplication_impl(std::index_sequenc
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>&& ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    void self_scalar_multiplication_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar)
+    constexpr void self_scalar_multiplication_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar)
         MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] *= static_cast<T>(scalar)), ...);
@@ -387,7 +388,7 @@ KOKKOS_INLINE_FUNCTION
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    auto matrix_scalar_division_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
+    constexpr auto matrix_scalar_division_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat, const U& scalar)
         -> AMatrix<scalar_quotient_result_t<T, U>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   using CommonType = scalar_quotient_result_t<T, U>;
@@ -401,7 +402,7 @@ KOKKOS_INLINE_FUNCTION
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor, typename U>
 MUNDY_REQUIRES(HasNonConstAccessOperator<Accessor, T>&& ValidScalarType<U>)
 KOKKOS_INLINE_FUNCTION
-    void self_scalar_division_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
+    constexpr void self_scalar_division_impl(std::index_sequence<Is...>, AMatrix<T, N, M, Accessor>& mat, const U& scalar) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   ((mat[Is] /= static_cast<T>(scalar)), ...);
 }
@@ -413,7 +414,7 @@ KOKKOS_INLINE_FUNCTION
 template <size_t... Is, typename T, size_t N, size_t M, typename U, typename V, ValidAccessor<T> Accessor,
           ValidAccessor<U> OtherAccessor>
 MUNDY_REQUIRES(std::is_arithmetic_v<V>)
-KOKKOS_INLINE_FUNCTION bool is_close_impl(std::index_sequence<Is...>, const AMatrix<U, N, M, Accessor>& mat1,
+KOKKOS_INLINE_FUNCTION constexpr bool is_close_impl(std::index_sequence<Is...>, const AMatrix<U, N, M, Accessor>& mat1,
                                           const AMatrix<T, N, M, OtherAccessor>& mat2, const V& tol) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   // Use the type of the tolerance to determine the comparison type
@@ -422,21 +423,21 @@ KOKKOS_INLINE_FUNCTION bool is_close_impl(std::index_sequence<Is...>, const AMat
 
 /// \brief Sum of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T sum_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T sum_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   return (mat[Is] + ...);
 }
 
 /// \brief Product of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T product_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T product_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   return (mat[Is] * ...);
 }
 
 /// \brief Min of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T min_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T min_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   // Initialize min_value with the first element
   T min_value = mat[0];
@@ -446,7 +447,7 @@ KOKKOS_INLINE_FUNCTION T min_impl(std::index_sequence<Is...>, const AMatrix<T, N
 
 /// \brief Max of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T max_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T max_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   // Initialize max_value with the first element
   T max_value = mat[0];
@@ -457,7 +458,7 @@ KOKKOS_INLINE_FUNCTION T max_impl(std::index_sequence<Is...>, const AMatrix<T, N
 /// \brief Variance of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor,
           typename OutputType = typename NumTraits<T>::NonInteger>
-KOKKOS_INLINE_FUNCTION OutputType variance_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr OutputType variance_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   OutputType inv_NM = static_cast<OutputType>(1.0) / static_cast<OutputType>(N * M);
   OutputType mat_mean = inv_NM * sum_impl(std::make_index_sequence<N * M>{}, mat);
@@ -468,35 +469,15 @@ KOKKOS_INLINE_FUNCTION OutputType variance_impl(std::index_sequence<Is...>, cons
 /// \brief Standard deviation of all elements
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor,
           typename OutputType = typename NumTraits<T>::NonInteger>
-KOKKOS_INLINE_FUNCTION OutputType standard_deviation_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr OutputType standard_deviation_impl(std::index_sequence<Is...>,
                                                           const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   return sqrt(variance_impl(std::make_index_sequence<N * M>{}, mat));
 }
 
-/// \brief AMatrix determinant (specialized for size 1 matrices)
-template <size_t N, size_t... Is, typename T, ValidAccessor<T> Accessor>
-MUNDY_REQUIRES(N == 1)
-KOKKOS_INLINE_FUNCTION T determinant_impl(std::index_sequence<Is...>, const AMatrix<T, N, N, Accessor>& mat) {
-  static_assert(sizeof...(Is) == N, "Number of indices must match number of columns in the matrix.");
-  return mat(0, 0);
-}
-
-/// \brief AMatrix determinant
-template <size_t N, size_t... Is, typename T, ValidAccessor<T> Accessor>
-MUNDY_REQUIRES(N != 1)
-KOKKOS_INLINE_FUNCTION T determinant_impl(std::index_sequence<Is...>, const AMatrix<T, N, N, Accessor>& mat) {
-  static_assert(sizeof...(Is) == N, "Number of indices must match number of columns in the matrix.");
-  // Recursively compute the determinant using the Laplace expansion
-  // Use views to avoid copying the matrix and some neat modulo arithmetic to determine the sign of each term.
-  return ((mat(0, Is) * determinant_impl<N - 1>(std::make_index_sequence<N - 1>{}, mat.template view_minor<0, Is>()) *
-           ((Is % 2 == 0) ? 1 : -1)) +
-          ...);
-}
-
 /// \brief AMatrix transpose
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<T, M, N> transpose_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr AMatrix<T, M, N> transpose_impl(std::index_sequence<Is...>,
                                                        const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
   AMatrix<T, M, N> result;
@@ -504,21 +485,10 @@ KOKKOS_INLINE_FUNCTION AMatrix<T, M, N> transpose_impl(std::index_sequence<Is...
   return result;
 }
 
-/// \brief AMatrix cofactors (only valid for square matrices)
-template <size_t... Is, typename T, size_t N, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AMatrix<T, N, N> cofactors_impl(std::index_sequence<Is...>,
-                                                       const AMatrix<T, N, N, Accessor>& mat) {
-  static_assert(sizeof...(Is) == N * N, "Number of indices must match number of elements in the matrix.");
-  AMatrix<T, N, N> result;
-  ((result[Is] = determinant(mat.template view_minor<Is / N, Is % N>()) * (((Is / N + Is % N) % 2 == 0) ? 1 : -1)),
-   ...);
-  return result;
-}
-
 /// \brief Frobenius inner product of two matrices
 template <size_t... Is, typename T, size_t N, size_t M, typename U, ValidAccessor<U> Accessor,
           ValidAccessor<T> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto frobenius_inner_product_impl(std::index_sequence<Is...>,
+KOKKOS_INLINE_FUNCTION constexpr auto frobenius_inner_product_impl(std::index_sequence<Is...>,
                                                          const AMatrix<U, N, M, Accessor>& mat1,
                                                          const AMatrix<T, N, M, OtherAccessor>& mat2)
     -> scalar_product_result_t<T, U> {
@@ -530,7 +500,7 @@ KOKKOS_INLINE_FUNCTION auto frobenius_inner_product_impl(std::index_sequence<Is.
 /// \brief Outer product of two vectors (result is a matrix)
 template <size_t... Is, typename T, size_t N, size_t M, typename U, ValidAccessor<U> Accessor,
           ValidAccessor<T> OtherAccessor>
-KOKKOS_INLINE_FUNCTION auto outer_product_impl(std::index_sequence<Is...>, const AVector<U, N, Accessor>& vec1,
+KOKKOS_INLINE_FUNCTION constexpr auto outer_product_impl(std::index_sequence<Is...>, const AVector<U, N, Accessor>& vec1,
                                                const AVector<T, M, OtherAccessor>& vec2)
     -> AMatrix<scalar_product_result_t<T, U>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the result matrix.");
@@ -542,7 +512,7 @@ KOKKOS_INLINE_FUNCTION auto outer_product_impl(std::index_sequence<Is...>, const
 
 /// \brief Infinity norm
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T inf_norm_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T inf_norm_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == N, "Number of indices must match number of rows in the matrix.");
   T max_value = abs(sum(mat.template view_row<0>()));
   ((max_value = max(max_value, abs(sum(mat.template view_row<Is>())))), ...);
@@ -551,7 +521,7 @@ KOKKOS_INLINE_FUNCTION T inf_norm_impl(std::index_sequence<Is...>, const AMatrix
 
 /// \brief One norm
 template <size_t... Is, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION T one_norm_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
+KOKKOS_INLINE_FUNCTION constexpr T one_norm_impl(std::index_sequence<Is...>, const AMatrix<T, N, M, Accessor>& mat) {
   static_assert(sizeof...(Is) == M, "Number of indices must match number of columns in the matrix.");
   // Max absolute column sum
   T max_value = abs(sum(mat.template view_column<0>()));
@@ -591,7 +561,7 @@ MUNDY_SUPPRESS_GPU_CALL_FROM_HOST_WARNINGS_PUSH
 
 /// \brief Apply a function to each element of the matrix
 template <size_t... Is, typename Func, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION auto apply_impl(std::index_sequence<Is...>, const Func& func,
+KOKKOS_INLINE_FUNCTION constexpr auto apply_impl(std::index_sequence<Is...>, const Func& func,
                                        const AMatrix<T, N, M, Accessor>& mat)
     -> AMatrix<std::invoke_result_t<Func, T>, N, M> {
   static_assert(sizeof...(Is) == N * M, "Number of indices must match number of elements in the matrix.");
@@ -603,7 +573,7 @@ KOKKOS_INLINE_FUNCTION auto apply_impl(std::index_sequence<Is...>, const Func& f
 
 /// \brief Apply a function to each row of the matrix
 template <size_t... Is, typename Func, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION auto apply_row_impl(std::index_sequence<Is...>, const Func& func,
+KOKKOS_INLINE_FUNCTION constexpr auto apply_row_impl(std::index_sequence<Is...>, const Func& func,
                                            const AMatrix<T, N, M, Accessor>& mat)
     -> AMatrix<typename std::invoke_result_t<Func, AVector<T, M>>::value_type, N, M> {
   static_assert(sizeof...(Is) == N, "Number of indices must match number of rows in the matrix.");
@@ -615,7 +585,7 @@ KOKKOS_INLINE_FUNCTION auto apply_row_impl(std::index_sequence<Is...>, const Fun
 
 /// \brief Apply a function to each column of the matrix
 template <size_t... Is, typename Func, typename T, size_t N, size_t M, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION auto apply_column_impl(std::index_sequence<Is...>, const Func& func,
+KOKKOS_INLINE_FUNCTION constexpr auto apply_column_impl(std::index_sequence<Is...>, const Func& func,
                                               const AMatrix<T, N, M, Accessor>& mat)
     -> AMatrix<typename std::invoke_result_t<Func, AVector<T, N>>::value_type, N, M> {
   static_assert(sizeof...(Is) == M, "Number of indices must match number of columns in the matrix.");

--- a/mundy/core/math/src/mundy_math/impl/MatrixInverseImpl.hpp
+++ b/mundy/core/math/src/mundy_math/impl/MatrixInverseImpl.hpp
@@ -1,0 +1,585 @@
+// @HEADER
+// **********************************************************************************************************************
+//
+//                                          Mundy: Multi-body Nonlocal Dynamics
+//                                              Copyright 2024 Bryce Palmer
+//
+// Developed under support from the NSF Graduate Research Fellowship Program.
+//
+// Mundy is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Mundy is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Mundy. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// **********************************************************************************************************************
+// @HEADER
+
+#ifndef MUNDY_MATH_IMPL_MATRIX_INVERSE_IMPL_HPP_
+#define MUNDY_MATH_IMPL_MATRIX_INVERSE_IMPL_HPP_
+
+/// \file MatrixInverseImpl.hpp
+/// \brief Implementation of determinant() and inverse() for fixed-size square matrices
+///
+/// determinant() and inverse() dispatch on N: a cofactor expansion for small N and LU decomposition for larger N.
+///
+/// # Bitmasked cofactors
+/// The cofactor expansion is implemented with a bitmask-based dynamic programming approach that computes all
+/// 2^N subdeterminants in a single pass, rather than recomputing a fresh table for each minor.
+///
+/// Naive cofactor expansion is recursive: det(A) = sum over one row/column of ± a[i][j] * det(minor(i,j)), and each
+/// (N-1)×(N-1) minor recurses the same way. The problem is that the same minor is reached by many different recursive
+/// paths (deleting row 2 then row 5 reaches the same submatrix as deleting row 5 then row 2), and naive recursion
+/// recomputes it every time it's reached.
+///
+/// The fix is to give every submatrix that can appear during expansion a canonical, memoizable name, so each gets
+/// computed exactly once. The trick used here: instead of naming a submatrix by "which rows/columns a particular
+/// recursive path happened to delete," name it by which set of columns it uses, paired with a fixed block of rows (the
+/// first k rows, or the last k rows). A set of columns over N ≤ 6 columns fits exactly in an N-bit integer — bit c set
+/// means "column c is in this submatrix." That integer is the memoizable key. Hence "bitmask."
+///
+/// # Laplace expansion with bitmasks
+/// The table built above is enough to get the determinant, using the whole matrix as one N-row block. But
+/// cofactors -- needed for the adjugate, and so for inverse() -- require the determinant of the minor with an
+/// *arbitrary* row r deleted, not just the last row. A single table over one fixed row range can't give you that.
+///
+/// The fix is the generalized Laplace expansion (a.k.a. Cauchy-Binet): split the N-1 surviving rows into "rows
+/// above r" (0..r-1) and "rows below r" (r+1..N-1), then for every way of handing r of the N-1 surviving columns to
+/// the top block (the rest going to the bottom block), that split contributes one term:
+///
+///   cofactor(r, c) = (-1)^(r+c) * sum over F, |F| = r, of (sign) * det(top block, cols F)
+///                        * det(bottom block, cols complement of F)
+///
+/// where F ranges over subsets of the N-1 columns other than c. Both of those block determinants are exactly the
+/// same shape of table as before -- determinant of a row block over a column subset -- just now needed for a *top*
+/// block (rows above r) and a *bottom* block (rows below r), for every possible r. So the code builds two tables,
+/// top_det and bottom_det, once each: top_det[Subset] is the determinant of rows 0..popcount(Subset)-1 using columns
+/// Subset, exactly as before; bottom_det[Subset] is its mirror image, using the *last* popcount(Subset) rows and
+/// expanding along that block's first row instead of its last. The plain determinant is just the degenerate case
+/// top_det[all N bits set], where every row lands in the top block. Building both tables costs the same
+/// O(N * 2^N) as before; every cofactor is then just a 2^(N-1)-term sum of table lookups -- no new recursion, and
+/// no separate table rebuilt per (row, col) minor the way a naive implementation would need.
+///
+/// # LU decomposition with partial pivoting
+/// Bitmask cofactors cost O(N * 2^N): far better than naive O(N!) recursion, but still exponential in N with a steep
+/// compile-time cost, so past kMatrixInverseLaplaceToLUCutoff (found empirically) it's cheaper to switch to an O(N^3)
+/// method -- LU decomposition with partial pivoting.
+///
+/// The idea: factor A as PA = LU, where P is a row permutation, L is unit lower triangular (an implicit 1 on the
+/// diagonal), and U is upper triangular. Partial pivoting picks, at each elimination step k, the largest-magnitude
+/// entry at or below the diagonal in column k and swaps its row into place before eliminating -- this keeps the
+/// division by the pivot numerically stable, and every swap performed builds up P and flips the sign of det(A).
+/// Eliminating column k introduces zeros below the diagonal that are never read again, so the elimination
+/// multiplier that produced each zero is stored right back into that now-unused slot: one N*N buffer ends up
+/// holding L below the diagonal and U on/above it, with no separate storage for either.
+///
+/// determinant() from here is det(A) = sign(P) * det(U), and det(U) is just the product of U's diagonal (L's
+/// diagonal is an implicit 1, so it contributes nothing). inverse() solves A X = I for all N columns of the
+/// identity at once: PA = LU means LU X = P (the permuted identity), which splits into two triangular solves --
+/// forward substitution for L Y = P, then back substitution for U X = Y -- with all N right-hand-side columns
+/// solved together rather than one at a time, since they share the same L and U.
+
+// C++ core
+#include <cstddef>
+
+// Mundy
+#include <mundy_math/impl/MatrixImpl.hpp>
+#include <mundy_math/NumTraits.hpp>
+#include <mundy_math/cmath.hpp>
+#include <mundy_utils/throw_assert.hpp>
+
+namespace mundy {
+
+namespace impl {
+    
+/// \brief Largest N for which determinant()/inverse() use the bitmask cofactor expansion instead of LU.
+inline constexpr size_t kMatrixInverseLaplaceToLUCutoff = 6;
+
+//! \name Bit utilities
+//@{
+
+/// \brief Number of set bits of x below bit position Bound.
+/// \param[in] x Value to count bits in.
+template <size_t Bound, size_t... Bits>
+KOKKOS_FORCEINLINE_FUNCTION constexpr int popcount_impl(size_t x, std::index_sequence<Bits...>) {
+  return (static_cast<int>((x >> Bits) & size_t{1}) + ...);
+}
+
+/// \brief Number of set bits of x below bit position Bound.
+/// \param[in] x Value to count bits in.
+template <size_t Bound>
+KOKKOS_FORCEINLINE_FUNCTION constexpr int popcount(size_t x) {
+  return popcount_impl<Bound>(x, std::make_index_sequence<Bound>{});
+}
+
+/// \brief Sum of the bit positions set in x below bit position Bound (e.g. 0b101 -> 0 + 2).
+/// \param[in] x Value to sum bit positions of.
+template <size_t Bound, size_t... Bits>
+KOKKOS_FORCEINLINE_FUNCTION constexpr int position_sum_impl(size_t x, std::index_sequence<Bits...>) {
+  return ((((x >> Bits) & size_t{1}) ? static_cast<int>(Bits) : 0) + ...);
+}
+
+/// \brief Sum of the bit positions set in x below bit position Bound (e.g. 0b101 -> 0 + 2).
+/// \param[in] x Value to sum bit positions of.
+template <size_t Bound>
+KOKKOS_FORCEINLINE_FUNCTION constexpr int position_sum(size_t x) {
+  return position_sum_impl<Bound>(x, std::make_index_sequence<Bound>{});
+}
+
+/// \brief The compressed_idx-th surviving index of a dimension with `excluded` removed, expressed as
+/// an index into the original (uncompressed) dimension.
+/// \param[in] compressed_idx Index into the reduced dimension (0..N-2).
+/// \param[in] excluded The index removed from the original dimension.
+KOKKOS_FORCEINLINE_FUNCTION constexpr size_t skip_index(size_t compressed_idx, size_t excluded) {
+  return compressed_idx < excluded ? compressed_idx : compressed_idx + 1;
+}
+
+//@}
+
+//! \name Bitmask cofactor expansion
+/// top_det[Subset]/bottom_det[Subset] hold the determinant of the top/bottom popcount(Subset) rows
+/// of the matrix, using columns Subset in relative order. Every cofactor is read off by combining
+/// the two tables instead of recomputing a fresh table per (row, col) minor.
+//@{
+
+/// \brief One term of the recursion
+///
+/// top_det[Subset] = sum over c in Subset of (-1)^(row+col) * mat(row, c) * top_det[Subset with c removed], 
+///    where k = |Subset| and (row, col) are c's position within the block
+/// (row is always k-1, its last row; col is c's rank among Subset's members).
+///
+/// \tparam Subset Column set (as a bitmask) being summed over.
+/// \param[in] mat Source matrix.
+/// \param[in] top_det Table of already-computed smaller-subset determinants.
+template <size_t N, size_t Subset, typename T, ValidAccessor<T> Accessor, size_t... Cols>
+KOKKOS_FORCEINLINE_FUNCTION constexpr T top_row_sum(const AMatrix<T, N, N, Accessor>& mat, const T* top_det,
+                                          std::index_sequence<Cols...>) {
+  static_assert(sizeof...(Cols) == N, "Number of columns must match N.");
+  constexpr int k = popcount<N>(Subset);  // |Subset|: rows 0..k-1 make up this block
+  return ((((Subset >> Cols) & size_t{1})  // only sum over c = Cols actually in Subset
+               ? (((k - 1 + popcount<N>(Subset & ((size_t{1} << Cols) - 1))) % 2 == 0) ? T(1) : T(-1)) *
+                     mat(static_cast<size_t>(k - 1), Cols) * top_det[Subset & ~(size_t{1} << Cols)]
+               : T(0)) +
+          ...);
+}
+
+/// \brief Fills top_det[1..2^N-1] in increasing order (top_det[Subset] only reads smaller entries).
+/// \param[in] mat Source matrix.
+/// \param[in,out] top_det Table to fill; top_det[0] = 1 must already be set.
+template <size_t N, typename T, ValidAccessor<T> Accessor, size_t... SubsetsMinusOne>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void fill_top_det(const AMatrix<T, N, N, Accessor>& mat, T* top_det,
+                                              std::index_sequence<SubsetsMinusOne...>) {
+  static_assert(sizeof...(SubsetsMinusOne) == (size_t{1} << N) - 1, "Number of subsets must match 2^N - 1.");
+  ((top_det[SubsetsMinusOne + 1] = top_row_sum<N, SubsetsMinusOne + 1>(mat, top_det, std::make_index_sequence<N>{})),
+   ...);
+}
+
+/// \brief One term of the recursion
+///
+/// bottom_det[Subset] = sum over c in Subset of (-1)^(row+col) * mat(row, c) * bottom_det[Subset with c removed],
+///    where k = |Subset| and (row, col) are c's position within the block
+/// (row is always N-k, the block's first row; col is c's rank among Subset's members).
+///
+/// \tparam Subset Column set (as a bitmask) being summed over.
+/// \param[in] mat Source matrix.
+/// \param[in] bottom_det Table of already-computed smaller-subset determinants.
+template <size_t N, size_t Subset, typename T, ValidAccessor<T> Accessor, size_t... Cols>
+KOKKOS_FORCEINLINE_FUNCTION constexpr T bottom_row_sum(const AMatrix<T, N, N, Accessor>& mat, const T* bottom_det,
+                                             std::index_sequence<Cols...>) {
+  static_assert(sizeof...(Cols) == N, "Number of columns must match N.");
+  constexpr int k = popcount<N>(Subset);
+  constexpr size_t row = N - static_cast<size_t>(k);  // first row of the last-k-rows block
+  return ((((Subset >> Cols) & size_t{1})
+               ? ((popcount<N>(Subset & ((size_t{1} << Cols) - 1)) % 2 == 0) ? T(1) : T(-1)) * mat(row, Cols) *
+                     bottom_det[Subset & ~(size_t{1} << Cols)]
+               : T(0)) +
+          ...);
+}
+
+/// \brief Fills bottom_det[1..2^N-1] in increasing order (bottom_det[Subset] only reads smaller entries).
+/// \param[in] mat Source matrix.
+/// \param[in,out] bottom_det Table to fill; bottom_det[0] = 1 must already be set.
+template <size_t N, typename T, ValidAccessor<T> Accessor, size_t... SubsetsMinusOne>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void fill_bottom_det(const AMatrix<T, N, N, Accessor>& mat, T* bottom_det,
+                                                 std::index_sequence<SubsetsMinusOne...>) {
+  static_assert(sizeof...(SubsetsMinusOne) == (size_t{1} << N) - 1, "Number of subsets must match 2^N - 1.");
+  ((bottom_det[SubsetsMinusOne + 1] =
+        bottom_row_sum<N, SubsetsMinusOne + 1>(mat, bottom_det, std::make_index_sequence<N>{})),
+   ...);
+}
+
+/// \brief Reindexes a bitmask over the N-1 columns surviving ExcludedCol's removal (renumbered 0..N-2)
+/// into the matching bitmask over the original N columns.
+/// \tparam ExcludedCol Column removed before renumbering.
+/// \tparam Local Bitmask over the renumbered column set.
+template <size_t N, size_t ExcludedCol, size_t Local, size_t... J>
+KOKKOS_FORCEINLINE_FUNCTION constexpr size_t scatter_impl(std::index_sequence<J...>) {
+  static_assert(sizeof...(J) == N - 1, "Number of local column indices must match N - 1.");
+  return ((((Local >> J) & size_t{1}) ? (size_t{1} << skip_index(J, ExcludedCol)) : size_t{0}) | ...);
+}
+
+/// \brief scatter_impl<N, ExcludedCol, Local>, memoized as a constant.
+template <size_t N, size_t ExcludedCol, size_t Local>
+inline constexpr size_t scattered_v = scatter_impl<N, ExcludedCol, Local>(std::make_index_sequence<N - 1>{});
+
+/// \brief Sign of the (ExcludedCol, Local) cofactor term. 
+///
+/// cofactor(r, c) is the determinant of the (N-1)x(N-1) minor (row r, col c removed); the generalized Laplace/Cauchy-
+/// Binet expansion splits it into a top r-row block (columns F) and a bottom (N-1-r)-row block (columns G, the rest):
+///   cofactor(r,c) = (-1)^(r+c) * sum over F, |F|=r, of
+///                   (-1)^(r(r-1)/2 + sum of F's local column positions) * top_det[F] * bottom_det[G].
+/// This is that sign for one term, with Local = F expressed in the reduced universe's local indices
+/// and r = popcount(Local).
+///
+/// \tparam ExcludedCol The excluded column c.
+/// \tparam Local The column set F, in the reduced universe's local indices.
+template <size_t N, size_t ExcludedCol, size_t Local>
+inline constexpr bool cofactor_term_positive_v = [] {
+  constexpr int r = popcount<N - 1>(Local);
+  constexpr int exponent = r + static_cast<int>(ExcludedCol) + (r * (r - 1)) / 2 + position_sum<N - 1>(Local);
+  return exponent % 2 == 0;
+}();
+
+/// \brief Computes cofactor(r, ExcludedCol) for every r in one pass
+/// each Local is one column split F from the Laplace sum, and since |F| = r, its term lands directly in col_acc[r].
+///
+/// \param[in] col_acc A view into result's column, forwarded in directly from view_column(); writes
+/// still land in result since the view only wraps a reference to its storage.
+/// \param[in] top_det Global top-block determinant table.
+/// \param[in] bottom_det Global bottom-block determinant table.
+template <size_t N, size_t ExcludedCol, typename T, ValidVectorType VectorType, size_t... Local>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void accumulate_column(VectorType&& col_acc, const T* top_det, const T* bottom_det,
+                                                   std::index_sequence<Local...>) {
+  static_assert(sizeof...(Local) == (size_t{1} << (N - 1)), "Number of local column subsets must match 2^(N-1).");
+  constexpr size_t full_mask = (size_t{1} << N) - 1;
+  // Note, ~scattered_v<N, ExcludedCol, Local> is the complement of the scattered column set, which still has ExcludedCol's bit set,
+  // so we clear that via & ~ (1 << ExcludedCol) to get the actual bottom block's column set.
+  ((col_acc[popcount<N - 1>(Local)] +=
+    (cofactor_term_positive_v<N, ExcludedCol, Local> ? T(1) : T(-1))  //
+    * top_det[scattered_v<N, ExcludedCol, Local>]                     //
+    * bottom_det[full_mask & ~(size_t{1} << ExcludedCol) & ~scattered_v<N, ExcludedCol, Local>]),
+   ...);
+}
+
+/// \brief Fills every column of the cofactor matrix from the global top/bottom determinant tables.
+/// \param[in,out] result Matrix being assembled; must already be zero-filled.
+/// \param[in] top_det Global top-block determinant table.
+/// \param[in] bottom_det Global bottom-block determinant table.
+template <size_t N, typename T, size_t... ExcludedCol>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void combine_all_columns(AMatrix<T, N, N>& result, const T* top_det, const T* bottom_det,
+                                                     std::index_sequence<ExcludedCol...>) {
+  static_assert(sizeof...(ExcludedCol) == N, "Number of excluded columns must match N.");
+  (accumulate_column<N, ExcludedCol>(result.template view_column<ExcludedCol>(), top_det, bottom_det,
+                                     std::make_index_sequence<(size_t{1} << (N - 1))>{}),
+   ...);
+}
+
+/// \brief Determinant via the bitmask cofactor expansion.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor>
+KOKKOS_FORCEINLINE_FUNCTION constexpr T bitmask_determinant(const AMatrix<T, N, N, Accessor>& mat) {
+  if constexpr (N == 0) {
+    return T(1);
+  } else {
+    constexpr size_t num_subsets = size_t{1} << N;
+    T top_det[num_subsets];
+    top_det[0] = T(1);  // det of the empty top block (0 rows, 0 columns) is 1
+    fill_top_det<N>(mat, top_det, std::make_index_sequence<num_subsets - 1>{});
+    return top_det[num_subsets - 1];  // all N bits set = every column = the whole matrix's determinant
+  }
+}
+
+/// \brief Cofactor matrix via the bitmask cofactor expansion.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor>
+KOKKOS_FORCEINLINE_FUNCTION constexpr AMatrix<T, N, N> bitmask_cofactors(const AMatrix<T, N, N, Accessor>& mat) {
+  static_assert(N >= 1, "cofactors is only defined for N >= 1.");
+  if constexpr (N == 1) {
+    return AMatrix<T, 1, 1>(T(1));
+  } else {
+    constexpr size_t num_subsets = size_t{1} << N;
+    T top_det[num_subsets];
+    top_det[0] = T(1);
+    fill_top_det<N>(mat, top_det, std::make_index_sequence<num_subsets - 1>{});
+
+    T bottom_det[num_subsets];
+    bottom_det[0] = T(1);
+    fill_bottom_det<N>(mat, bottom_det, std::make_index_sequence<num_subsets - 1>{});
+
+    AMatrix<T, N, N> result(T(0));  // accumulate_column writes via +=, so result must start zeroed
+    combine_all_columns<N>(result, top_det, bottom_det, std::make_index_sequence<N>{});
+    return result;
+  }
+}
+
+//@}
+
+//! \name LU decomposition with partial pivoting
+//@{
+
+/// \brief Swaps the values of a and b.
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr void swap_val(T& a, T& b) {
+  T tmp = a;
+  a = b;
+  b = tmp;
+}
+
+/// \brief Sets perm to the identity permutation.
+/// \param[out] perm Permutation array, size N.
+template <size_t N, size_t... Idx>
+KOKKOS_INLINE_FUNCTION constexpr void init_perm(size_t* perm, std::index_sequence<Idx...>) {
+  static_assert(sizeof...(Idx) == N, "Number of indices must match N.");
+  ((perm[Idx] = Idx), ...);
+}
+
+/// \brief Finds the largest-magnitude entry at or below the diagonal in column K.
+/// \param[in] mat Matrix being factorized in place, row-major layout.
+/// \param[in,out] pivot_row Best candidate row found so far.
+/// \param[in,out] pivot_mag |mat[pivot_row][K]|, the best candidate's magnitude so far.
+template <size_t N, size_t K, typename T, size_t... Offset>
+KOKKOS_INLINE_FUNCTION constexpr void find_pivot(const AMatrix<T, N, N>& mat, size_t& pivot_row, T& pivot_mag,
+                                       std::index_sequence<Offset...>) {
+  static_assert(sizeof...(Offset) == N - K - 1, "Number of candidate rows must match N - K - 1.");
+  (
+      [&] {
+        constexpr size_t candidate_row = K + 1 + Offset;
+        const T mag = mundy::abs(mat[candidate_row * N + K]);
+        if (mag > pivot_mag) {
+          pivot_mag = mag;
+          pivot_row = candidate_row;
+        }
+      }(),
+      ...);
+}
+
+/// \brief Swaps rows K and pivot_row across all N columns. pivot_row is a runtime fact about the
+/// matrix (found by find_pivot), so this is the one place in this file where mat is addressed by a
+/// runtime offset rather than a compile-time one.
+/// \param[in,out] mat Matrix being factorized in place, row-major layout.
+/// \param[in] pivot_row Row to swap with row K.
+template <size_t N, size_t K, typename T, size_t... Col>
+KOKKOS_INLINE_FUNCTION constexpr void swap_rows(AMatrix<T, N, N>& mat, size_t pivot_row, std::index_sequence<Col...>) {
+  static_assert(sizeof...(Col) == N, "Number of columns must match N.");
+  (swap_val(mat[K * N + Col], mat[pivot_row * N + Col]), ...);
+}
+
+/// \brief Eliminates mat[Row][K], storing its multiplier in the now-unused lower-triangular slot
+/// (the compact in-place LU representation) and updating the rest of the row.
+/// \param[in,out] mat Matrix being factorized in place, row-major layout.
+/// \param[in] pivot_recip 1/mat[K][K].
+template <size_t N, size_t K, size_t Row, typename T, size_t... ColOffset>
+KOKKOS_INLINE_FUNCTION constexpr void eliminate_row(AMatrix<T, N, N>& mat, T pivot_recip, std::index_sequence<ColOffset...>) {
+  static_assert(sizeof...(ColOffset) == N - K - 1, "Number of columns to eliminate must match N - K - 1.");
+  const T multiplier = mat[Row * N + K] * pivot_recip;  // L[Row][K] = A[Row][K] / A[K][K]
+  mat[Row * N + K] = multiplier;
+  // A[Row][j] -= L[Row][K] * A[K][j] for every j > K -- the standard elimination update.
+  ((mat[Row * N + (K + 1 + ColOffset)] -= multiplier * mat[K * N + (K + 1 + ColOffset)]), ...);
+}
+
+/// \brief Eliminates column K below the diagonal for every row K+1..N-1.
+/// \param[in,out] mat Matrix being factorized in place, row-major layout.
+template <size_t N, size_t K, typename T, size_t... RowOffset>
+KOKKOS_INLINE_FUNCTION constexpr void eliminate_step(AMatrix<T, N, N>& mat, std::index_sequence<RowOffset...>) {
+  static_assert(sizeof...(RowOffset) == N - K - 1, "Number of rows to eliminate must match N - K - 1.");
+  const T pivot_recip = T(1) / mat[K * N + K];  // 1/A[K][K], shared by every row eliminated below
+  (eliminate_row<N, K, K + 1 + RowOffset>(mat, pivot_recip, std::make_index_sequence<N - K - 1>{}), ...);
+}
+
+/// \brief One elimination step (pivot, swap, eliminate) for column K.
+/// \param[in,out] mat Matrix being factorized in place, row-major layout.
+/// \param[in,out] perm Row permutation, size N.
+/// \return -1 if a row swap occurred, +1 otherwise.
+template <size_t N, size_t K, typename T>
+KOKKOS_INLINE_FUNCTION constexpr int lu_step(AMatrix<T, N, N>& mat, size_t* perm) {
+  size_t pivot_row = K;
+  T pivot_mag = mundy::abs(mat[K * N + K]);
+  find_pivot<N, K>(mat, pivot_row, pivot_mag, std::make_index_sequence<N - K - 1>{});
+
+  int sign_flip = 1;
+  if (pivot_row != K) {
+    swap_rows<N, K>(mat, pivot_row, std::make_index_sequence<N>{});
+    swap_val(perm[K], perm[pivot_row]);
+    sign_flip = -1;
+  }
+
+  eliminate_step<N, K>(mat, std::make_index_sequence<N - K - 1>{});
+  return sign_flip;
+}
+
+/// \brief Factorizes mat into LU form in place and a row permutation. Steps K = 0..N-2 run in order
+/// via a comma fold's guaranteed left-to-right sequencing, so step K+1 always sees step K's result.
+/// \param[in,out] mat Matrix to factorize in place; L below diagonal, U on/above.
+/// \param[out] perm Row permutation, size N.
+/// \return The sign contributed by the permutation (+1 or -1).
+template <size_t N, typename OutputType, size_t... K>
+KOKKOS_INLINE_FUNCTION constexpr int factorize(AMatrix<OutputType, N, N>& mat, size_t* perm, std::index_sequence<K...>) {
+  static_assert(sizeof...(K) == N - 1, "Number of elimination steps must match N - 1.");
+  init_perm<N>(perm, std::make_index_sequence<N>{});
+  int sign = 1;
+  ((sign *= lu_step<N, K>(mat, perm)), ...);  // sign of the permutation = product of each swap's +-1
+  return sign;
+}
+
+/// \brief det(U): L's diagonal is an implicit 1, so this is the only real factor left to multiply out.
+/// \param[in] mat Factorized matrix, row-major layout.
+template <size_t N, typename T, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr T diagonal_product(const AMatrix<T, N, N>& mat, std::index_sequence<I...>) {
+  static_assert(sizeof...(I) == N, "Number of indices must match N.");
+  return (mat[I * N + I] * ...);
+}
+
+/// \brief Sets Y to the permuted identity: to solve A x_c = e_c for every column c at once, note PA =
+/// LU means LU x_c = P e_c, and (P e_c)[row] = e_c[perm[row]] = 1 iff perm[row]==c. So Y starts as P
+/// itself, one column per c.
+/// \param[out] Y Right-hand-side matrix.
+/// \param[in] perm Row permutation, size N.
+template <size_t N, typename T, size_t... Idx>
+KOKKOS_INLINE_FUNCTION constexpr void init_permuted_rhs_matrix(AMatrix<T, N, N>& Y, const size_t* perm,
+                                                     std::index_sequence<Idx...>) {
+  static_assert(sizeof...(Idx) == N * N, "Number of indices must match N*N.");
+  ((Y[Idx] = (perm[Idx / N] == Idx % N) ? T(1) : T(0)), ...);
+}
+
+/// \brief sum_{j<Row} L[Row][j] * Y[j][Col], the part of L*Y = rhs already known once rows 0..Row-1
+/// are solved.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in] Y Right-hand-side/solution matrix.
+template <size_t N, size_t Row, size_t Col, typename T, size_t... J>
+KOKKOS_INLINE_FUNCTION constexpr T forward_sum_one(const AMatrix<T, N, N>& mat, const AMatrix<T, N, N>& Y,
+                                         std::index_sequence<J...>) {
+  static_assert(sizeof...(J) == Row, "Number of summed terms must match Row.");
+  if constexpr (sizeof...(J) == 0) {
+    return T(0);
+  } else {
+    return ((mat[Row * N + J] * Y[J * N + Col]) + ...);
+  }
+}
+
+/// \brief Updates all N columns of row Row at once (they're mutually independent for a fixed row).
+/// Y[Row][Col] holds rhs[Row][Col] going in; subtracting the known sum leaves L[Row][Row]*x = ...,
+/// and L's diagonal is an implicit 1, so this *is* Y[Row][Col] after solving -- no division needed.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in,out] Y Right-hand-side/solution matrix.
+template <size_t N, size_t Row, typename T, size_t... Col>
+KOKKOS_INLINE_FUNCTION constexpr void forward_row_all_cols(const AMatrix<T, N, N>& mat, AMatrix<T, N, N>& Y,
+                                                 std::index_sequence<Col...>) {
+  static_assert(sizeof...(Col) == N, "Number of columns must match N.");
+  ((Y[Row * N + Col] -= forward_sum_one<N, Row, Col>(mat, Y, std::make_index_sequence<Row>{})), ...);
+}
+
+/// \brief Solves L*Y = (permuted identity) in place, L's unit diagonal implicit. Rows must resolve
+/// in increasing order (row i needs every Y[j][*], j<i, already finalized), guaranteed by the comma
+/// fold's left-to-right sequencing over a plain increasing index_sequence.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in,out] Y Right-hand-side/solution matrix.
+template <size_t N, typename T, size_t... Row>
+KOKKOS_INLINE_FUNCTION constexpr void forward_substitute_batch(const AMatrix<T, N, N>& mat, AMatrix<T, N, N>& Y,
+                                                     std::index_sequence<Row...>) {
+  static_assert(sizeof...(Row) == N, "Number of rows must match N.");
+  (forward_row_all_cols<N, Row>(mat, Y, std::make_index_sequence<N>{}), ...);
+}
+
+/// \brief sum_{j>Row} U[Row][j] * Y[j][Col], the part of U*X = Y already known once rows Row+1..N-1
+/// are solved.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in] Y Right-hand-side/solution matrix.
+template <size_t N, size_t Row, size_t Col, typename T, size_t... ColOffset>
+KOKKOS_INLINE_FUNCTION constexpr T back_sum_one(const AMatrix<T, N, N>& mat, const AMatrix<T, N, N>& Y,
+                                      std::index_sequence<ColOffset...>) {
+  static_assert(sizeof...(ColOffset) == N - 1 - Row, "Number of summed terms must match N - 1 - Row.");
+  if constexpr (sizeof...(ColOffset) == 0) {
+    return T(0);
+  } else {
+    return ((mat[Row * N + (Row + 1 + ColOffset)] * Y[(Row + 1 + ColOffset) * N + Col]) + ...);
+  }
+}
+
+/// \brief Updates all N columns of row Row at once: X[Row][Col] = (Y[Row][Col] - sum_{j>Row}
+/// U[Row][j]*X[j][Col]) / U[Row][Row], written in place over Y.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in] inv_diag_row 1/U[Row][Row], precomputed once for the whole matrix.
+/// \param[in,out] Y Right-hand-side/solution matrix.
+template <size_t N, size_t Row, typename T, size_t... Col>
+KOKKOS_INLINE_FUNCTION constexpr void back_row_all_cols(const AMatrix<T, N, N>& mat, T inv_diag_row, AMatrix<T, N, N>& Y,
+                                              std::index_sequence<Col...>) {
+  static_assert(sizeof...(Col) == N, "Number of columns must match N.");
+  ((Y[Row * N + Col] = (Y[Row * N + Col] - back_sum_one<N, Row, Col>(mat, Y, std::make_index_sequence<N - 1 - Row>{})) *
+                        inv_diag_row),
+   ...);
+}
+
+/// \brief Solves U*X = Y in place. Rows must resolve in decreasing order; folding over the usual
+/// increasing 0..N-1 and mapping I -> row = N-1-I visits row N-1 first, then N-2, ..., without
+/// needing a descending index_sequence.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[in] inv_diag 1/U[i][i] for every i.
+/// \param[in,out] Y Right-hand-side/solution matrix.
+template <size_t N, typename T, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr void back_substitute_batch(const AMatrix<T, N, N>& mat, const T* inv_diag,
+                                                            AMatrix<T, N, N>& Y, std::index_sequence<I...>) {
+  static_assert(sizeof...(I) == N, "Number of rows must match N.");
+  (
+      [&] {
+        constexpr size_t row = N - 1 - I;
+        back_row_all_cols<N, row>(mat, inv_diag[row], Y, std::make_index_sequence<N>{});
+      }(),
+      ...);
+}
+
+/// \brief Computes 1/U[i][i] for every i, shared by every column's back-substitution.
+/// \param[in] mat Factorized matrix, row-major layout.
+/// \param[out] inv_diag Reciprocal diagonal, size N.
+template <size_t N, typename T, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr void compute_inv_diag(const AMatrix<T, N, N>& mat, T* inv_diag,
+                                                       std::index_sequence<I...>) {
+  static_assert(sizeof...(I) == N, "Number of indices must match N.");
+  ((inv_diag[I] = T(1) / mat[I * N + I]), ...);
+}
+
+/// \brief Determinant via fixed-size LU decomposition with partial pivoting.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType>
+KOKKOS_INLINE_FUNCTION constexpr OutputType lu_determinant(const AMatrix<T, N, N, Accessor>& mat) {
+  if constexpr (N == 0) {
+    return OutputType(1);
+  } else {
+    AMatrix<OutputType, N, N> mat_work = mat.template cast<OutputType>();
+    size_t perm[N];
+    const int sign = factorize<N>(mat_work, perm, std::make_index_sequence<N - 1>{});
+    return static_cast<OutputType>(sign) *
+           diagonal_product<N>(mat_work, std::make_index_sequence<N>{});  // det(A) = sign * det(U)
+  }
+}
+
+/// \brief Inverse via fixed-size LU decomposition with partial pivoting: factorize once, then solve
+/// A*X = I for all N columns of the identity together.
+/// \param[in] mat Source matrix.
+template <size_t N, typename T, ValidAccessor<T> Accessor, typename OutputType>
+KOKKOS_INLINE_FUNCTION constexpr AMatrix<OutputType, N, N> lu_inverse(const AMatrix<T, N, N, Accessor>& mat) {
+  AMatrix<OutputType, N, N> mat_work = mat.template cast<OutputType>();
+  size_t perm[N];
+  const int sign = factorize<N>(mat_work, perm, std::make_index_sequence<N - 1>{});
+  const OutputType det = static_cast<OutputType>(sign) *
+                         diagonal_product<N>(mat_work, std::make_index_sequence<N>{});  // det(A) = sign * det(U)
+  MUNDY_THROW_ASSERT(det != OutputType(0), std::runtime_error, "inverse: matrix is singular.");
+
+  OutputType inv_diag[N];
+  compute_inv_diag<N>(mat_work, inv_diag, std::make_index_sequence<N>{});
+
+  AMatrix<OutputType, N, N> Y;
+  init_permuted_rhs_matrix<N>(Y, perm, std::make_index_sequence<N * N>{});
+  forward_substitute_batch<N>(mat_work, Y, std::make_index_sequence<N>{});
+  back_substitute_batch<N>(mat_work, inv_diag, Y, std::make_index_sequence<N>{});
+  return Y;
+}
+//@}
+
+}  // namespace impl
+
+}  // namespace mundy
+
+#endif  // MUNDY_MATH_IMPL_MATRIX_INVERSE_IMPL_HPP_

--- a/mundy/core/math/src/mundy_math/impl/VectorImpl.hpp
+++ b/mundy/core/math/src/mundy_math/impl/VectorImpl.hpp
@@ -105,9 +105,9 @@ KOKKOS_INLINE_FUNCTION
 
 /// \brief Cast (and copy) the vector to a different type
 template <typename U, size_t... Is, typename T, size_t N, ValidAccessor<T> Accessor>
-KOKKOS_INLINE_FUNCTION AVector<U, N> cast_impl(std::index_sequence<Is...>, const AVector<T, N, Accessor>& vec) {
+KOKKOS_INLINE_FUNCTION constexpr AVector<U, N> cast_impl(std::index_sequence<Is...>, const AVector<T, N, Accessor>& vec) {
   static_assert(sizeof...(Is) == N, "Number of indices must match number of elements in the vector.");
-  return AVector<U, N>{static_cast<U>(vec[Is])...};
+  return AVector<U, N>(static_cast<U>(vec[Is])...);
 }
 
 /// \brief Unary minus operator

--- a/mundy/core/math/tests/performance_tests/CMakeLists.txt
+++ b/mundy/core/math/tests/performance_tests/CMakeLists.txt
@@ -34,6 +34,13 @@ if(Mundy_ENABLE_TESTS AND Mundy_ENABLE_nanobench)
     INSTALLABLE
     CATEGORIES PERFORMANCE
   )
+
+  tribits_add_executable(
+    MatrixInvDet
+    SOURCES MatrixInvDet.cpp
+    INSTALLABLE
+    CATEGORIES PERFORMANCE
+  )
 else()
   message(STATUS
     "MundyMath: Skipping performance tests since Mundy_ENABLE_TESTS=OFF or Mundy_ENABLE_nanobench=OFF ...")

--- a/mundy/core/math/tests/performance_tests/MatrixInvDet.cpp
+++ b/mundy/core/math/tests/performance_tests/MatrixInvDet.cpp
@@ -1,0 +1,134 @@
+// @HEADER
+// **********************************************************************************************************************
+//
+//                                          Mundy: Multi-body Nonlocal Dynamics
+//                                              Copyright 2024 Bryce Palmer
+//
+// Developed under support from the NSF Graduate Research Fellowship Program.
+//
+// Mundy is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Mundy is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Mundy. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// **********************************************************************************************************************
+// @HEADER
+
+//! \file OldMatrixInverse.cpp
+/// \brief Runtime benchmark of mundy::determinant/inverse
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+
+// C++ core
+#include <cstdlib>  // for rand, RAND_MAX
+#include <string>   // for std::string
+#include <vector>   // for std::vector
+
+// External
+#include "nanobench.h"
+
+// Trilinos
+#include <Kokkos_Core.hpp>                 // for Kokkos::initialize, Kokkos::finalize
+#include <stk_util/parallel/Parallel.hpp>  // for stk::parallel_machine_init, stk::parallel_machine_finalize
+
+// Mundy
+#include <mundy_math/Matrix.hpp>  // for mundy::Matrix, mundy::determinant/cofactors/adjugate/inverse
+
+/// \brief Fill `data` (num_matrices * N * N flattened doubles) with diagonally-dominant (hence
+/// well-conditioned and invertible) N x N matrices.
+void randomize_diag_dominant(std::vector<double>& data, size_t N) {
+  const size_t num_matrices = data.size() / (N * N);
+  for (size_t m = 0; m < num_matrices; ++m) {
+    double* block = data.data() + m * N * N;
+    for (size_t i = 0; i < N; ++i) {
+      for (size_t j = 0; j < N; ++j) {
+        block[i * N + j] = (static_cast<double>(rand()) / RAND_MAX) * 2.0 - 1.0;
+      }
+      block[i * N + i] += 5.0 * static_cast<double>(N);  // diagonally dominant regardless of N
+    }
+  }
+}
+
+template <size_t N>
+void bench_det(size_t num_matrices) {
+  std::vector<double> data(num_matrices * N * N);
+  randomize_diag_dominant(data, N);
+
+  double checksum = 0.0;  // laundered through doNotOptimizeAway so the batch loop can't be elided
+
+  ankerl::nanobench::Bench det_bench;
+  det_bench.title("determinant, Matrix<double," + std::to_string(N) + "," + std::to_string(N) + ">")
+      .unit("op")
+      .batch(num_matrices)
+      .performanceCounters(true)
+      .minEpochIterations(20);
+  det_bench.run("det", [&] {
+    for (size_t m = 0; m < num_matrices; ++m) {
+      const auto mat = mundy::get_matrix_view<double, N, N>(data.data() + m * N * N);
+      checksum += mundy::determinant(mat);
+    }
+    ankerl::nanobench::doNotOptimizeAway(checksum);
+  });
+}
+
+template <size_t N>
+void bench_inv(size_t num_matrices) {
+  std::vector<double> data(num_matrices * N * N);
+  randomize_diag_dominant(data, N);
+
+  double checksum = 0.0;  // laundered through doNotOptimizeAway so the batch loop can't be elided
+
+  ankerl::nanobench::Bench inv_bench;
+  inv_bench.title("inverse, Matrix<double," + std::to_string(N) + "," + std::to_string(N) + ">")
+      .unit("op")
+      .batch(num_matrices)
+      .performanceCounters(true)
+      .minEpochIterations(20);
+  inv_bench.run("inv", [&] {
+    for (size_t m = 0; m < num_matrices; ++m) {
+      const auto mat = mundy::get_matrix_view<double, N, N>(data.data() + m * N * N);
+      checksum += mundy::inverse(mat)(0, 0);
+    }
+    ankerl::nanobench::doNotOptimizeAway(checksum);
+  });
+}
+
+int main(int argc, char** argv) {
+  stk::parallel_machine_init(&argc, &argv);
+  Kokkos::initialize(argc, argv);
+
+  const size_t num_matrices = 5000;
+
+  bench_det<2>(num_matrices);
+  bench_det<3>(num_matrices);
+  bench_det<4>(num_matrices);
+  bench_det<5>(num_matrices);
+  bench_det<6>(num_matrices);
+  bench_det<7>(num_matrices);
+  bench_det<8>(num_matrices);
+  bench_det<9>(num_matrices);
+  bench_det<10>(num_matrices);
+  bench_det<11>(num_matrices);
+  bench_det<12>(num_matrices);
+
+  bench_inv<2>(num_matrices);
+  bench_inv<3>(num_matrices);
+  bench_inv<4>(num_matrices);
+  bench_inv<5>(num_matrices);
+  bench_inv<6>(num_matrices);
+  bench_inv<7>(num_matrices);
+  bench_inv<8>(num_matrices);
+  bench_inv<9>(num_matrices);
+  bench_inv<10>(num_matrices);
+  bench_inv<11>(num_matrices);
+  bench_inv<12>(num_matrices);
+
+  Kokkos::finalize();
+  stk::parallel_machine_finalize();
+
+  return 0;
+}

--- a/mundy/core/math/tests/unit_tests/UnitTestMinimize.cpp
+++ b/mundy/core/math/tests/unit_tests/UnitTestMinimize.cpp
@@ -169,7 +169,7 @@ TEST(Minimize, ComplexFunctions) {
   constexpr size_t N = 42;
 
   {
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     double min_cost =
         find_min_using_approximate_derivatives<lbfgs_max_memory_size>(rosenbrock<N>, x, min_objective_delta);
     EXPECT_NEAR(min_cost, 0.0, test_tolerance);
@@ -254,7 +254,7 @@ TEST(MinimizeWithDerivatives, ComplexFunctions) {
   constexpr size_t N = 42;
 
   {
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     double min_cost =
         find_min_with_derivatives<lbfgs_max_memory_size>(rosenbrock<N>, rosenbrock_grad<N>, x, min_objective_delta);
     EXPECT_NEAR(min_cost, 0.0, test_tolerance);
@@ -310,14 +310,14 @@ TEST(MinimizeWithDerivatives, FewerFunctionEvaluationsRosenbrock) {
 
   {
     CountedF<N, decltype(rosenbrock<N>)> cf(rosenbrock<N>, f_count_approx);
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     find_min_using_approximate_derivatives<lbfgs_max_memory_size>(cf, x, min_objective_delta);
   }
 
   {
     CountedF<N, decltype(rosenbrock<N>)> cf(rosenbrock<N>, f_count_exact);
     CountedDF<N, decltype(rosenbrock_grad<N>)> cdf(rosenbrock_grad<N>, g_count_exact);
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     find_min_with_derivatives<lbfgs_max_memory_size>(cf, cdf, x, min_objective_delta);
   }
 
@@ -342,10 +342,10 @@ TEST(MinimizeWithDerivatives, SolutionMatchesApproximate) {
   const double match_tol = std::sqrt(min_objective_delta);
   constexpr size_t N = 10;
 
-  Vector<double, N> x_approx = {0.0};
+  Vector<double, N> x_approx(0.0);
   find_min_using_approximate_derivatives<lbfgs_max_memory_size>(rosenbrock<N>, x_approx, min_objective_delta);
 
-  Vector<double, N> x_exact = {0.0};
+  Vector<double, N> x_exact(0.0);
   find_min_with_derivatives<lbfgs_max_memory_size>(rosenbrock<N>, rosenbrock_grad<N>, x_exact, min_objective_delta);
 
   for (size_t i = 0; i < N; ++i) {
@@ -399,7 +399,7 @@ TEST(MinimizeWithFDF, ComplexFunctions) {
     g = rosenbrock_grad<N>(x);
     return rosenbrock<N>(x);
   };
-  Vector<double, N> x = {0.0};
+  Vector<double, N> x(0.0);
   double min_cost = find_min_with_fdf<lbfgs_max_memory_size>(fdf, x, min_objective_delta);
   EXPECT_NEAR(min_cost, 0.0, test_tolerance);
   for (size_t i = 0; i < N; ++i) EXPECT_NEAR(x[i], 1.0, test_tolerance);
@@ -451,14 +451,14 @@ TEST(MinimizeWithFDF, FewerEvaluationsRosenbrock) {
   {
     CountedF<N, decltype(rosenbrock<N>)> cf(rosenbrock<N>, f_exact);
     CountedDF<N, decltype(rosenbrock_grad<N>)> cdf(rosenbrock_grad<N>, g_exact);
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     find_min_with_derivatives<lbfgs_max_memory_size>(cf, cdf, x, min_objective_delta);
   }
 
   {
     CountedFDF<N, decltype(rosenbrock<N>), decltype(rosenbrock_grad<N>)> cfdf(rosenbrock<N>, rosenbrock_grad<N>,
                                                                               fdf_count);
-    Vector<double, N> x = {0.0};
+    Vector<double, N> x(0.0);
     find_min_with_fdf<lbfgs_max_memory_size>(cfdf, x, min_objective_delta);
   }
 

--- a/mundy/core/utils/src/mundy_utils/aggregate.hpp
+++ b/mundy/core/utils/src/mundy_utils/aggregate.hpp
@@ -798,25 +798,29 @@ class aggregate {
 
   /// \brief Get tagged object of the given args: Perform get<I'th tag>()(args...) with syntactic sugar
   template <size_t I, typename... Args>
-  MUNDY_REQUIRES(impl::callable_with<const typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>)
+  MUNDY_REQUIRES(impl::callable_with<const typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr decltype(auto) get(Args&&... args) const {
     return get<I>()(std::forward<Args>(args)...);
   }
   template <size_t I, typename... Args>
-  MUNDY_REQUIRES(impl::callable_with<typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>)
+  MUNDY_REQUIRES(impl::callable_with<typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr decltype(auto) get(Args&&... args) {
     return get<I>()(std::forward<Args>(args)...);
   }
 
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
   template <size_t I, typename... Args>
-  MUNDY_REQUIRES(!impl::callable_with<const typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>)
+  MUNDY_REQUIRES(!impl::callable_with<const typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) const {
     static_assert(impl::callable_with<const typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>,
                   "The I'th value is not callable with the given arguments.");
   }
   template <size_t I, typename... Args>
-  MUNDY_REQUIRES(!impl::callable_with<typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>)
+  MUNDY_REQUIRES(!impl::callable_with<typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) {
     static_assert(impl::callable_with<typename type_at_index_t<I, TaggedComponents...>::value_type&, Args...>,
                   "The I'th value is not callable with the given arguments.");
@@ -828,27 +832,30 @@ class aggregate {
   MUNDY_REQUIRES(
       contains_tag_v<Tag, TaggedComponents...>&& impl::callable_with<
           const typename type_at_index_t<index_of_tag_v<Tag, TaggedComponents...>, TaggedComponents...>::value_type&,
-          Args...>)
+          Args...> &&
+      sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr decltype(auto) get(Args&&... args) const {
     return get<Tag>()(std::forward<Args>(args)...);
   }
   template <typename Tag, typename... Args>
-  MUNDY_REQUIRES(contains_tag_v<Tag, TaggedComponents...>&& impl::callable_with<
-                 typename type_at_index_t<index_of_tag_v<Tag, TaggedComponents...>, TaggedComponents...>::value_type&,
-                 Args...>)
+  MUNDY_REQUIRES(
+      contains_tag_v<Tag, TaggedComponents...>&& impl::callable_with<
+          typename type_at_index_t<index_of_tag_v<Tag, TaggedComponents...>, TaggedComponents...>::value_type&,
+          Args...> &&
+      sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr decltype(auto) get(Args&&... args) {
     return get<Tag>()(std::forward<Args>(args)...);
   }
 
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
   template <typename Tag, typename... Args>
-  MUNDY_REQUIRES(!contains_tag_v<Tag, TaggedComponents...>)
+  MUNDY_REQUIRES(!contains_tag_v<Tag, TaggedComponents...> && sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) const {
     static_assert(contains_tag_v<Tag, TaggedComponents...>,
                   "Attempting to get a value that does not exist in the aggregate");
   }
   template <typename Tag, typename... Args>
-  MUNDY_REQUIRES(!contains_tag_v<Tag, TaggedComponents...>)
+  MUNDY_REQUIRES(!contains_tag_v<Tag, TaggedComponents...> && sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) {
     static_assert(contains_tag_v<Tag, TaggedComponents...>,
                   "Attempting to get a value that does not exist in the aggregate");
@@ -858,7 +865,8 @@ class aggregate {
   MUNDY_REQUIRES(contains_tag_v<Tag, TaggedComponents...> &&
                  !impl::callable_with<const typename type_at_index_t<index_of_tag_v<Tag, TaggedComponents...>,
                                                                      TaggedComponents...>::value_type&,
-                                      Args...>)
+                                      Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) const {
     static_assert(
         impl::callable_with<
@@ -870,7 +878,8 @@ class aggregate {
   MUNDY_REQUIRES(contains_tag_v<Tag, TaggedComponents...> &&
                  !impl::callable_with<typename type_at_index_t<index_of_tag_v<Tag, TaggedComponents...>,
                                                                TaggedComponents...>::value_type&,
-                                      Args...>)
+                                      Args...> &&
+                 sizeof...(Args) > 0)
   KOKKOS_INLINE_FUNCTION constexpr void get(Args&&... /*args*/) {
     static_assert(
         impl::callable_with<

--- a/mundy/mesh/src/mundy_mesh/Aggregate.hpp
+++ b/mundy/mesh/src/mundy_mesh/Aggregate.hpp
@@ -670,7 +670,12 @@ class NgpAggregate {
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 /// \brief A deduction guide to allow for Aggregate() instead of Aggregate<>()
 template <typename... TaggedComponents>
-Aggregate(TaggedComponents...) -> Aggregate<TaggedComponents...>;
+Aggregate(const stk::mesh::BulkData& bulk_data, stk::mesh::Selector selector, TaggedComponents... components)
+    -> Aggregate<std::decay_t<TaggedComponents>...>;
+/// \brief A deduction guide to allow for Aggregate() instead of Aggregate<>()
+template <typename... TaggedComponents>
+Aggregate(const stk::mesh::BulkData& bulk_data, stk::mesh::Selector selector, tuple<TaggedComponents...> components)
+    -> Aggregate<std::decay_t<TaggedComponents>...>;
 #endif
 
 /// \brief Get a component of the given aggregate (const)

--- a/mundy/mesh/src/mundy_mesh/Class.hpp
+++ b/mundy/mesh/src/mundy_mesh/Class.hpp
@@ -39,6 +39,9 @@
 #include <utility>
 #include <vector>
 
+// Trilinos
+#include <Trilinos_version.h>  // for TRILINOS_MAJOR_MINOR_VERSION
+
 // STK
 #include <stk_io/FieldAndName.hpp>
 #include <stk_io/IossBridge.hpp>
@@ -795,10 +798,59 @@ inline Class& declare_class_impl(stk::mesh::MetaData& meta_data, Class::Type cla
   return class_map.append(std::move(class_ptr));
 }
 
+#if TRILINOS_MAJOR_MINOR_VERSION < 160100  // get_defined_output_fields introduced in Trilinos 16.1.0
+
+// Creates a hidden friend that returns a pointer to the selected member.
+template <class Tag, typename Tag::type Member>
+struct PrivateMemberExposer {
+  friend typename Tag::type get_private_member(Tag) noexcept {
+    return Member;
+  }
+};
+
+struct NamedFieldsTag {
+  using type = std::vector<stk::io::FieldAndName> stk::io::impl::OutputFile::*;
+
+  friend type get_private_member(NamedFieldsTag) noexcept;
+};
+
+// Deliberately extracts a pointer to OutputFile::m_namedFields.
+template struct PrivateMemberExposer<NamedFieldsTag, &stk::io::impl::OutputFile::m_namedFields>;
+
+// m_outputFiles is protected, so the ordinary derived-class
+// pointer-to-member technique works for this level.
+struct BrokerAccess : stk::io::StkMeshIoBroker {
+  static const auto& output_files(const stk::io::StkMeshIoBroker& broker) noexcept {
+    return broker.*(&BrokerAccess::m_outputFiles);
+  }
+};
+
+const inline std::vector<stk::io::FieldAndName>& named_fields(const stk::io::impl::OutputFile& outputFile) {
+  const auto member = get_private_member(NamedFieldsTag{});
+  return outputFile.*member;
+}
+#endif
+
+const inline std::vector<stk::io::FieldAndName>& get_defined_output_fields(const stk::io::StkMeshIoBroker& broker,
+                                                                    std::size_t outputFileIndex) {
+#if TRILINOS_MAJOR_MINOR_VERSION >= 160100
+  return broker.get_defined_output_fields(outputFileIndex);
+#else
+  const auto& outputFiles = BrokerAccess::output_files(broker);
+  MUNDY_THROW_REQUIRE(outputFileIndex < outputFiles.size(), std::out_of_range,
+                      "Invalid STK output-file index in get_defined_output_fields().");
+  MUNDY_THROW_REQUIRE(
+      outputFiles[outputFileIndex] != nullptr, std::logic_error,
+      sink() << "STK output file at index " << outputFileIndex << " is null in get_defined_output_fields().");
+  return named_fields(*outputFiles[outputFileIndex]);
+#endif
+}
+
 /// \brief Return whether the broker already has the given field/name pair registered.
 inline bool is_output_field_registered(const stk::io::StkMeshIoBroker& io_broker, size_t output_file_index,
                                        const stk::mesh::FieldBase& field, const std::string& db_name) {
-  const std::vector<stk::io::FieldAndName>& named_fields = io_broker.get_defined_output_fields(output_file_index);
+  const std::vector<stk::io::FieldAndName>& named_fields =
+      get_defined_output_fields(io_broker, output_file_index);
   for (const stk::io::FieldAndName& named_field : named_fields) {
     if (named_field.field() == &field && named_field.db_name() == db_name) {
       return true;
@@ -859,7 +911,8 @@ template <typename ComponentType>
 inline constexpr bool has_direct_field_v = requires(ComponentType& component) { component.field(); };
 
 template <typename ComponentType>
-inline constexpr bool has_nested_component_field_v = requires(ComponentType& component) { component.component().field(); };
+inline constexpr bool has_nested_component_field_v =
+    requires(ComponentType& component) { component.component().field(); };
 
 template <typename ComponentType>
 decltype(auto) class_component_field(ComponentType& component) {
@@ -1237,13 +1290,13 @@ inline void add_class_field(stk::io::StkMeshIoBroker& io_broker, size_t output_f
 
 /// \brief Register a component for output using Class-aware IO rules over an explicit class set.
 ///
-/// Shared components do not currently have an IO representation. Passing a shared component here is a no-op that prints a
-/// warning once.
+/// Shared components do not currently have an IO representation. Passing a shared component here is a no-op that prints
+/// a warning once.
 template <typename ComponentType>
 inline void add_class_component(stk::io::StkMeshIoBroker& io_broker, size_t output_file_index, ComponentType& component,
                                 const ClassVector& classes, const std::string& db_name) {
   static_assert(!std::is_const_v<std::remove_reference_t<ComponentType>>,
-              "add_class_component requires a non-const component.");
+                "add_class_component requires a non-const component.");
   if constexpr (impl::has_class_component_field_v<ComponentType>) {
     add_class_field(io_broker, output_file_index, impl::class_component_field(component), classes, db_name);
   } else {
@@ -1256,7 +1309,7 @@ template <typename ComponentType>
 inline void add_class_component(stk::io::StkMeshIoBroker& io_broker, size_t output_file_index, ComponentType& component,
                                 const ClassVector& classes) {
   static_assert(!std::is_const_v<std::remove_reference_t<ComponentType>>,
-              "add_class_component requires a non-const component.");
+                "add_class_component requires a non-const component.");
   if constexpr (impl::has_class_component_field_v<ComponentType>) {
     stk::mesh::FieldBase& field = impl::class_component_field(component);
     add_class_component(io_broker, output_file_index, component, classes, field.name());
@@ -1272,16 +1325,17 @@ template <typename ComponentType>
 inline void add_class_component(stk::io::StkMeshIoBroker& io_broker, size_t output_file_index, ComponentType& component,
                                 const std::string& db_name) {
   static_assert(!std::is_const_v<std::remove_reference_t<ComponentType>>,
-              "add_class_component requires a non-const component.");
+                "add_class_component requires a non-const component.");
   add_class_component(io_broker, output_file_index, component,
                       impl::filter_io_supported_classes(get_classes(io_broker.bulk_data().mesh_meta_data())), db_name);
 }
 
 /// \brief Register a component for output using Class-aware IO rules.
 template <typename ComponentType>
-inline void add_class_component(stk::io::StkMeshIoBroker& io_broker, size_t output_file_index, ComponentType& component) {
+inline void add_class_component(stk::io::StkMeshIoBroker& io_broker, size_t output_file_index,
+                                ComponentType& component) {
   static_assert(!std::is_const_v<std::remove_reference_t<ComponentType>>,
-              "add_class_component requires a non-const component.");
+                "add_class_component requires a non-const component.");
   if constexpr (impl::has_class_component_field_v<ComponentType>) {
     stk::mesh::FieldBase& field = impl::class_component_field(component);
     add_class_component(io_broker, output_file_index, component, field.name());

--- a/mundy/mesh/src/mundy_mesh/FieldComponent.hpp
+++ b/mundy/mesh/src/mundy_mesh/FieldComponent.hpp
@@ -613,6 +613,30 @@ class NgpOBBFieldComponent : public impl::NgpFieldComponent<NgpFieldType, impl::
   }
 };  // NgpOBBFieldComponent
 
+#if !defined(DOXYGEN_SHOULD_SKIP_THIS)
+// Deduction guides!
+template <typename ScalarType>
+FieldComponent(stk::mesh::Field<ScalarType>&) -> FieldComponent<ScalarType>;
+template <typename NgpFieldType>
+NgpFieldComponent(NgpFieldType) -> NgpFieldComponent<NgpFieldType>;
+template <typename ScalarType>
+ScalarFieldComponent(stk::mesh::Field<ScalarType>&) -> ScalarFieldComponent<ScalarType>;
+template <typename NgpFieldType>
+NgpScalarFieldComponent(NgpFieldType) -> NgpScalarFieldComponent<NgpFieldType>;
+template <typename ScalarType>
+QuaternionFieldComponent(stk::mesh::Field<ScalarType>&) -> QuaternionFieldComponent<ScalarType>;
+template <typename NgpFieldType>
+NgpQuaternionFieldComponent(NgpFieldType) -> NgpQuaternionFieldComponent<NgpFieldType>;
+template <typename ScalarType>
+AABBFieldComponent(stk::mesh::Field<ScalarType>&) -> AABBFieldComponent<ScalarType>;
+template <typename NgpFieldType>
+NgpAABBFieldComponent(NgpFieldType) -> NgpAABBFieldComponent<NgpFieldType>;
+template <typename ScalarType>
+OBBFieldComponent(stk::mesh::Field<ScalarType>&) -> OBBFieldComponent<ScalarType>;
+template <typename NgpFieldType>
+NgpOBBFieldComponent(NgpFieldType) -> NgpOBBFieldComponent<NgpFieldType>;
+#endif
+
 /// \brief A helper function for getting the NGP component from a regular component.
 ///
 /// Field-backed components simply wrap STK's updated ngp field and return the wrapper by value.

--- a/mundy/mesh/src/mundy_mesh/LinkCSRData.hpp
+++ b/mundy/mesh/src/mundy_mesh/LinkCSRData.hpp
@@ -437,6 +437,14 @@ class LinkCSRDataT {  // Raw data in any space
   }
   //@}
 
+  //! \name Friends <3
+  //@{
+
+  /// \brief We are not, by-default, a fiend of other memory spaces
+  template <typename OtherMemSpace>
+  friend class LinkCSRDataT;
+  //@}
+
  private:
   //! \name Internal members (host only)
   //@{

--- a/mundy/mesh/src/mundy_mesh/LinkMetaData.hpp
+++ b/mundy/mesh/src/mundy_mesh/LinkMetaData.hpp
@@ -35,14 +35,16 @@
 // Trilinos libs
 #include <Trilinos_version.h>  // for TRILINOS_MAJOR_MINOR_VERSION
 
-#include <stk_io/IossBridge.hpp>                // for stk::io::set_field_role, stk::io::Field
-#include <stk_io/StkMeshIoBroker.hpp>           // for stk::io::StkMeshIoBroker
-#include <stk_mesh/base/Entity.hpp>             // for stk::mesh::Entity
-#include <stk_mesh/base/Field.hpp>              // for stk::mesh::Field
-#include <stk_mesh/base/Part.hpp>               // stk::mesh::Part
-#include <stk_mesh/base/Selector.hpp>           // stk::mesh::Selector
-#include <stk_mesh/base/Types.hpp>              // for stk::mesh::EntityRank
-#include <stk_util/parallel/OutputStreams.hpp>  // for stk::outputP0
+#include <stk_io/IossBridge.hpp>       // for stk::io::set_field_role, stk::io::Field
+#include <stk_io/StkMeshIoBroker.hpp>  // for stk::io::StkMeshIoBroker
+#include <stk_mesh/base/Entity.hpp>    // for stk::mesh::Entity
+#include <stk_mesh/base/Field.hpp>     // for stk::mesh::Field
+#include <stk_mesh/base/Part.hpp>      // stk::mesh::Part
+#include <stk_mesh/base/Selector.hpp>  // stk::mesh::Selector
+#include <stk_mesh/base/Types.hpp>     // for stk::mesh::EntityRank
+#if TRILINOS_MAJOR_MINOR_VERSION >= 161000
+#include <stk_util/parallel/OutputStreams.hpp>  // for stk::outputP0 (introduced in Tril16.1)
+#endif
 
 // Mundy libs
 #include <mundy_mesh/BulkData.hpp>  // for mundy::mesh::BulkData
@@ -110,11 +112,18 @@ class LinkMetaData {
             declare_class(meta_data, std::string("MUNDY_UNIVERSAL_") + our_name + "_" + rank_to_string(link_rank_),
                           link_rank_, /* disable io support */ link_rank_ == stk::topology::ELEM_RANK)) {
     if (link_rank_ == stk::topology::ELEM_RANK) {
-      // Only print on rank zero to avoid redundant warnings in parallel runs
+// Only print on rank zero to avoid redundant warnings in parallel runs
+#if TRILINOS_MAJOR_MINOR_VERSION > 161000
       stk::outputP0() << "Warning: LinkMetaData '" << our_name_
                       << "' is using a non-IO universal element-rank link class because STK IO does not yet support "
                          "ELEMENT_RANK sets."
                       << std::endl;
+#else
+      std::cerr << "Warning: LinkMetaData '" << our_name_
+                << "' is using a non-IO universal element-rank link class because STK IO does not yet support "
+                   "ELEMENT_RANK sets."
+                << std::endl;
+#endif
     }
 
     int link_crs_needs_updated_start_valid[1] = {1};

--- a/mundy/mesh/src/mundy_mesh/NgpModRequests.hpp
+++ b/mundy/mesh/src/mundy_mesh/NgpModRequests.hpp
@@ -483,7 +483,11 @@ class NgpRequestEntitiesImplT {
 
   /// \brief Constructor.
   NgpRequestEntitiesImplT(unsigned helper_index)
+  #if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
       : state_(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpRequestEntitiesImplT::state")) {
+        #else
+      : state_(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpRequestEntitiesImplT::state")) {
+  #endif
     state_().index_ = helper_index;
     state_().active_space_dev_view_ = bool_view_t("NgpRequestEntitiesImplT::active_space_dev_view");
     state_().active_space_host_view_ = Kokkos::create_mirror_view(state_().active_space_dev_view_);
@@ -799,7 +803,11 @@ class NgpRequestConnectionsT {
   void initialize() {
     MUNDY_THROW_ASSERT(!state_.is_allocated(), std::runtime_error,
                        "NgpRequestConnectionsT::initialize() called on already initialized object.");
+#if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
     state_ = state_view_t(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpRequestConnectionsT::state"));
+#else
+    state_ = state_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpRequestConnectionsT::state"));
+#endif
     state_().active_space_dev_view_ = bool_view_t("NgpRequestConnectionsT::active_space_dev_view");
     state_().active_space_host_view_ = Kokkos::create_mirror_view(state_().active_space_dev_view_);
     state_().ticket_issuer_ = ticket_issuer_t(/*activate_device*/ true);
@@ -1012,7 +1020,11 @@ class NgpRequestLinkRelationsT {
   void initialize() {
     MUNDY_THROW_ASSERT(!state_.is_allocated(), std::runtime_error,
                        "NgpRequestLinkRelationsT::initialize() called on already initialized object.");
+  #if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
     state_ = state_view_t(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpRequestLinkRelationsT::state"));
+  #else
+    state_ = state_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpRequestLinkRelationsT::state"));
+  #endif
     state_().active_space_dev_view_ = bool_view_t("NgpRequestLinkRelationsT::active_space_dev_view");
     state_().active_space_host_view_ = Kokkos::create_mirror_view(state_().active_space_dev_view_);
     state_().ticket_issuer_ = ticket_issuer_t(/*activate_device*/ true);
@@ -1182,7 +1194,11 @@ class NgpDestroyEntitiesT {
   void initialize() {
     MUNDY_THROW_ASSERT(!state_.is_allocated(), std::runtime_error,
                        "NgpDestroyEntitiesT::initialize() called on already initialized object.");
+#if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
     state_ = state_view_t(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpDestroyEntitiesT::state"));
+#else
+    state_ = state_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpDestroyEntitiesT::state"));
+#endif
     state_().active_space_dev_view_ = bool_view_t("NgpDestroyEntitiesT::active_space_dev_view");
     state_().active_space_host_view_ = Kokkos::create_mirror_view(state_().active_space_dev_view_);
     state_().ticket_issuer_ = ticket_issuer_t(/*activate_device*/ true);
@@ -1371,7 +1387,11 @@ class NgpDestroyConnectionsT {
   void initialize() {
     MUNDY_THROW_ASSERT(!state_.is_allocated(), std::runtime_error,
                        "NgpDestroyConnectionsT::initialize() called on already initialized object.");
+#if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
     state_ = state_view_t(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpDestroyConnectionsT::state"));
+#else
+    state_ = state_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpDestroyConnectionsT::state"));
+#endif
     state_().active_space_dev_view_ = bool_view_t("NgpDestroyConnectionsT::active_space_dev_view");
     state_().active_space_host_view_ = Kokkos::create_mirror_view(state_().active_space_dev_view_);
     state_().ticket_issuer_ = ticket_issuer_t(/*activate_device*/ true);
@@ -1563,8 +1583,13 @@ class NgpModRequestsT {
 
   /// \brief Default constructor.
   NgpModRequestsT()
+  #if KOKKOS_VERSION >= 40401  // SequentialHostInit introduced in Kokkos 4.4.01
       : shared_state_(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpModRequestsT::shared_state")),
         host_state_(Kokkos::view_alloc(Kokkos::SequentialHostInit, "NgpModRequestsT::host_state")) {
+  #else
+      : shared_state_(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpModRequestsT::shared_state")),
+        host_state_(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NgpModRequestsT::host_state")) {
+  #endif
     shared_state_().initialize();
   }
 

--- a/mundy/mesh/tests/performance_tests/CMakeLists.txt
+++ b/mundy/mesh/tests/performance_tests/CMakeLists.txt
@@ -94,3 +94,18 @@ else()
   message(STATUS
     "MundyMesh: Skipping performance tests since Mundy_ENABLE_TESTS=OFF or Mundy_ENABLE_nanobench=OFF ...")
 endif()
+
+# if(Mundy_ENABLE_TESTS AND Mundy_ENABLE_GTest)
+#   message(STATUS "MundyMesh: Setting up KokkosMbody correctness tests since Mundy_ENABLE_TESTS=ON and Mundy_ENABLE_GTest=ON")
+
+#   mundy_tribits_add_executable_and_test(
+#     KokkosMbodyTest
+#     SOURCES KokkosMbody.cpp
+#     MPI_PROC_RANGE 1
+#     INSTALLABLE
+#     CATEGORIES PERFORMANCE
+#   )
+# else()
+#   message(STATUS
+#     "MundyMesh: Skipping KokkosMbody correctness tests since Mundy_ENABLE_TESTS=OFF or Mundy_ENABLE_GTest=OFF ...")
+# endif()

--- a/mundy/mesh/tests/performance_tests/PerfTestSharedComponents.cpp
+++ b/mundy/mesh/tests/performance_tests/PerfTestSharedComponents.cpp
@@ -404,6 +404,13 @@ static void bench_drag_host(const BenchOptions& opts) {
   else std::cout << out.str();
 }
 
+void eval_drag_velocity_step(auto ngp_mesh, stk::mesh::Selector &selector, auto ngp_force_comp, auto ngp_vel_comp, auto drag) {
+    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, selector,
+        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
+            drag_velocity_step(drag(idx), ngp_force_comp(idx), ngp_vel_comp(idx));
+        });
+  }
+
 static void bench_drag_ngp(const BenchOptions& opts) {
   auto f = build_fixture(opts.num_entities);
   FC_v force_comp(*f.force), vel_comp(*f.velocity);
@@ -417,10 +424,8 @@ static void bench_drag_ngp(const BenchOptions& opts) {
   auto ngp_drag_sc    = get_updated_ngp_component(drag_sc);  // by value: NgpSharedScalarComponent
 
   auto run = [&](auto drag) {
-    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, f.selector,
-        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
-            drag_velocity_step(drag(idx), ngp_force_comp(idx), ngp_vel_comp(idx));
-        });
+   // Can't have a KOKKOS_LAMBDA inside a generic lambda (CUDA restriction), so we need a separate function for the NGP drag step.
+    eval_drag_velocity_step(ngp_mesh, f.selector, ngp_force_comp, ngp_vel_comp, drag);
   };
   auto run_field = [&] {
     ngp_force_comp.sync_to_device(); ngp_vel_comp.sync_to_device(); ngp_drag_fc.sync_to_device();
@@ -477,6 +482,14 @@ static void bench_mobility_host(const BenchOptions& opts) {
   else std::cout << out.str();
 }
 
+void eval_rigid_body_mobility_step(auto ngp_mesh, stk::mesh::Selector &selector, auto ngp_ambient, auto ngp_mobility, auto ngp_force_comp, auto ngp_orient_comp, auto ngp_vel_comp) {
+    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, selector,
+        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
+            rigid_body_mobility_step(ngp_ambient(idx), ngp_mobility(idx),
+                ngp_force_comp(idx), ngp_orient_comp(idx), ngp_vel_comp(idx));
+        });
+  }
+
 static void bench_mobility_ngp(const BenchOptions& opts) {
   auto f = build_fixture(opts.num_entities);
   FC_v force_comp(*f.force), vel_comp(*f.velocity);
@@ -496,11 +509,7 @@ static void bench_mobility_ngp(const BenchOptions& opts) {
   auto& ngp_mobility_sc = get_updated_ngp_component(mobility_sc);
 
   auto run = [&](auto ambient, auto mobility) {
-    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, f.selector,
-        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
-            rigid_body_mobility_step(ambient(idx), mobility(idx),
-                ngp_force_comp(idx), ngp_orient_comp(idx), ngp_vel_comp(idx));
-        });
+    eval_rigid_body_mobility_step(ngp_mesh, f.selector, ambient, mobility, ngp_force_comp, ngp_orient_comp, ngp_vel_comp);
   };
   auto run_field = [&] {
     ngp_force_comp.sync_to_device(); ngp_orient_comp.sync_to_device(); ngp_vel_comp.sync_to_device();
@@ -565,6 +574,18 @@ static void bench_complex_host(const BenchOptions& opts) {
   else std::cout << out.str();
 }
 
+void eval_rigid_body_step(auto ngp_mesh, stk::mesh::Selector &selector, auto dt, auto ambient, auto drag, auto target,
+                          auto ngp_force_comp, auto ngp_torque_comp, auto ngp_orient_comp, auto ngp_mobility_comp,
+                          auto ngp_vel_comp, auto ngp_stress_comp, auto ngp_orient_out_comp, auto ngp_energy_comp) {
+    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, selector,
+        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
+            rigid_body_step(dt(idx), ambient(idx), drag(idx), target(idx),
+                ngp_force_comp(idx), ngp_torque_comp(idx), ngp_orient_comp(idx),
+                ngp_mobility_comp(idx), ngp_vel_comp(idx), ngp_stress_comp(idx),
+                ngp_orient_out_comp(idx), ngp_energy_comp(idx));
+        });
+  }
+
 static void bench_complex_ngp(const BenchOptions& opts) {
   auto f = build_fixture(opts.num_entities);
   // Per-entity fields
@@ -612,13 +633,9 @@ static void bench_complex_ngp(const BenchOptions& opts) {
   };
 
   auto run = [&](auto dt, auto ambient, auto drag, auto target) {
-    mundy::mesh::for_each_entity_run(ngp_mesh, stk::topology::NODE_RANK, f.selector,
-        KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex& idx) {
-            rigid_body_step(dt(idx), ambient(idx), drag(idx), target(idx),
-                ngp_force_comp(idx), ngp_torque_comp(idx), ngp_orient_comp(idx),
-                ngp_mobility_comp(idx), ngp_vel_comp(idx), ngp_stress_comp(idx),
-                ngp_orient_out_comp(idx), ngp_energy_comp(idx));
-        });
+    eval_rigid_body_step(ngp_mesh, f.selector, dt, ambient, drag, target,
+        ngp_force_comp, ngp_torque_comp, ngp_orient_comp, ngp_mobility_comp,
+        ngp_vel_comp, ngp_stress_comp, ngp_orient_out_comp, ngp_energy_comp);
   };
   auto run_field = [&] {
     sync_per_entity_comps();

--- a/mundy/mesh/tests/unit_tests/UnitTestAccessorExpr.cpp
+++ b/mundy/mesh/tests/unit_tests/UnitTestAccessorExpr.cpp
@@ -1747,6 +1747,7 @@ VECTOR_SCALAR_OP_TEST(VectorOp_VectorScalarExprDivide,   "vector / vector / scal
           const auto vel_val = ExpectedValues::vel(c);                                                              \
           const auto force_val = ExpectedValues::force(c);                                                          \
           const double d = (ctx.vector_shape == ExprInputShape::RawAccessor) ? 1.0 : 2.0;                          \
+          /*maybe consumed by Comp0, Comp1, Comp2*/                                                                \
           [[maybe_unused]] const double tv0 = vel_val[0] / d;                                                       \
           [[maybe_unused]] const double tv1 = vel_val[1] / d;                                                       \
           [[maybe_unused]] const double tv2 = vel_val[2] / d;                                                       \
@@ -1768,6 +1769,7 @@ VECTOR_SCALAR_OP_TEST(VectorOp_VectorScalarExprDivide,   "vector / vector / scal
           const auto vel_val   = ExpectedValues::vel(c);                                               \
           const auto force_val = ExpectedValues::force(c);                                             \
           const double d = (ctx.vector_shape == ExprInputShape::RawAccessor) ? 1.0 : 2.0;             \
+          /*maybe consumed by Comp0, Comp1, Comp2*/                                                   \
           [[maybe_unused]] const double tv0 = vel_val[0] / d;                                         \
           [[maybe_unused]] const double tv1 = vel_val[1] / d;                                         \
           [[maybe_unused]] const double tv2 = vel_val[2] / d;                                         \

--- a/mundy/mesh/tests/unit_tests/UnitTestComponent.cpp
+++ b/mundy/mesh/tests/unit_tests/UnitTestComponent.cpp
@@ -191,11 +191,11 @@ static_assert(has_default_copy_move_assign_v<NgpTaggedComponent<POSITION, NgpSha
 
 TEST_F(UnitTestComponentFixture, FieldComponentExposeTypedViewsAndMutations) {
   FieldComponent<double> raw_accessor(*quaternion_field_ptr_);
-  auto scalar_accessor = ScalarFieldComponent(*scalar_field_ptr_);
-  auto vector3_accessor = Vector3FieldComponent(*vector3_field_ptr_);
-  auto matrix3_accessor = Matrix3FieldComponent(*matrix3_field_ptr_);
-  auto quaternion_accessor = QuaternionFieldComponent(*quaternion_field_ptr_);
-  auto aabb_accessor = AABBFieldComponent(*aabb_field_ptr_);
+  ScalarFieldComponent<double> scalar_accessor(*scalar_field_ptr_);
+  Vector3FieldComponent<double> vector3_accessor(*vector3_field_ptr_);
+  Matrix3FieldComponent<double> matrix3_accessor(*matrix3_field_ptr_);
+  QuaternionFieldComponent<double> quaternion_accessor(*quaternion_field_ptr_);
+  AABBFieldComponent<double> aabb_accessor(*aabb_field_ptr_);
 
   auto scalar1 = scalar_accessor(node1_);
   auto scalar2 = scalar_accessor(node2_);
@@ -245,8 +245,8 @@ TEST_F(UnitTestComponentFixture, FieldComponentExposeTypedViewsAndMutations) {
 }
 
 TEST_F(UnitTestComponentFixture, ShallowCopyAssignment) {
-  auto lhs_accessor = ScalarFieldComponent(*scalar_field_ptr_);
-  auto rhs_accessor = ScalarFieldComponent(*scalar_alt_field_ptr_);
+  ScalarFieldComponent<double> lhs_accessor(*scalar_field_ptr_);
+  ScalarFieldComponent<double> rhs_accessor(*scalar_alt_field_ptr_);
 
   lhs_accessor = rhs_accessor;
 
@@ -261,12 +261,38 @@ TEST_F(UnitTestComponentFixture, ShallowCopyAssignment) {
   EXPECT_DOUBLE_EQ(scalar_field_data(*scalar_field_ptr_, node1_)[0], 1.0);
 }
 
+void mutate_components_on_device(const NgpScalarFieldComponent<stk::mesh::NgpField<double>>& ngp_scalar_accessor,
+                                     const NgpVector3FieldComponent<stk::mesh::NgpField<double>>& ngp_vector3_accessor,
+                                     const NgpMatrix3FieldComponent<stk::mesh::NgpField<double>>& ngp_matrix3_accessor,
+                                     const NgpQuaternionFieldComponent<stk::mesh::NgpField<double>>& ngp_quaternion_accessor,
+                                     const NgpAABBFieldComponent<stk::mesh::NgpField<double>>& ngp_aabb_accessor,
+                                     stk::mesh::FastMeshIndex node1_index) {
+  Kokkos::parallel_for(
+      "mutate_components_on_device", Kokkos::RangePolicy<>(0, 1), KOKKOS_LAMBDA(int) {
+        ngp_scalar_accessor(node1_index)[0] += 2.5;
+
+        auto vector3 = ngp_vector3_accessor(node1_index);
+        vector3.set(7.0, 8.0, 9.0);
+
+        auto matrix3 = ngp_matrix3_accessor(node1_index);
+        matrix3(0, 1) = 222.0;
+        matrix3(2, 2) = 333.0;
+
+        auto quaternion = ngp_quaternion_accessor(node1_index);
+        quaternion.set(4.0, 5.0, 6.0, 7.0);
+
+        auto aabb = ngp_aabb_accessor(node1_index);
+        aabb.x_min() = -1.0;
+        aabb.z_max() = 99.0;
+      });
+}
+
 TEST_F(UnitTestComponentFixture, NgpFieldComponentRoundTripDeviceMutations) {
-  auto scalar_accessor = ScalarFieldComponent(*scalar_field_ptr_);
-  auto vector3_accessor = Vector3FieldComponent(*vector3_field_ptr_);
-  auto matrix3_accessor = Matrix3FieldComponent(*matrix3_field_ptr_);
-  auto quaternion_accessor = QuaternionFieldComponent(*quaternion_field_ptr_);
-  auto aabb_accessor = AABBFieldComponent(*aabb_field_ptr_);
+  ScalarFieldComponent<double> scalar_accessor(*scalar_field_ptr_);
+  Vector3FieldComponent<double> vector3_accessor(*vector3_field_ptr_);
+  Matrix3FieldComponent<double> matrix3_accessor(*matrix3_field_ptr_);
+  QuaternionFieldComponent<double> quaternion_accessor(*quaternion_field_ptr_);
+  AABBFieldComponent<double> aabb_accessor(*aabb_field_ptr_);
 
   auto ngp_scalar_accessor = get_updated_ngp_component(scalar_accessor);
   auto ngp_vector3_accessor = get_updated_ngp_component(vector3_accessor);
@@ -294,24 +320,10 @@ TEST_F(UnitTestComponentFixture, NgpFieldComponentRoundTripDeviceMutations) {
   auto ngp_mesh = stk::mesh::get_updated_ngp_mesh(bulk_data());
   stk::mesh::FastMeshIndex node1_index = ngp_mesh.fast_mesh_index(node1_);
 
-  Kokkos::parallel_for(
-      "mutate_components_on_device", Kokkos::RangePolicy<>(0, 1), KOKKOS_LAMBDA(int) {
-        ngp_scalar_accessor(node1_index)[0] += 2.5;
-
-        auto vector3 = ngp_vector3_accessor(node1_index);
-        vector3.set(7.0, 8.0, 9.0);
-
-        auto matrix3 = ngp_matrix3_accessor(node1_index);
-        matrix3(0, 1) = 222.0;
-        matrix3(2, 2) = 333.0;
-
-        auto quaternion = ngp_quaternion_accessor(node1_index);
-        quaternion.set(4.0, 5.0, 6.0, 7.0);
-
-        auto aabb = ngp_aabb_accessor(node1_index);
-        aabb.x_min() = -1.0;
-        aabb.z_max() = 99.0;
-      });
+  // KOKKOS_LAMBDA cannot be called in a GTEST test body due to CUDA's rule about:
+  // "The enclosing parent function ("TestBody") for an extended __host__ __device__ lambda cannot have private or protected access within its class"
+  mutate_components_on_device(ngp_scalar_accessor, ngp_vector3_accessor, ngp_matrix3_accessor, ngp_quaternion_accessor,
+                                   ngp_aabb_accessor, node1_index);
   Kokkos::fence();
 
   ngp_scalar_accessor.modify_on_device();
@@ -364,7 +376,7 @@ TEST_F(UnitTestComponentFixture, SharedComponentSupportsOwnedAndAliasedConstruct
   Kokkos::View<double*, Kokkos::HostSpace> managed_view("managed_shared_value", 1);
   managed_view(0) = 0.5;
 
-  auto managed_component = SharedScalarComponent(managed_view);
+  SharedScalarComponent<double> managed_component(managed_view);
   EXPECT_EQ(&managed_component.shared_value(), managed_view.data());
   managed_component(node1_)[0] = 1.25;
   EXPECT_DOUBLE_EQ(managed_view(0), 1.25);
@@ -391,7 +403,7 @@ TEST_F(UnitTestComponentFixture, SharedComponentRejectsBadViewsAndEnforcesSyncPr
   Kokkos::View<double*, Kokkos::HostSpace> bad_view("bad_shared_value", 2);
   EXPECT_THROW((void)SharedScalarComponent(bad_view), std::invalid_argument);
 
-  auto shared_component = SharedScalarComponent(2.0);
+  SharedScalarComponent<double> shared_component(2.0);
   auto ngp_shared_component = get_updated_ngp_component(shared_component);
 
   shared_component.modify_on_host();
@@ -406,7 +418,7 @@ TEST_F(UnitTestComponentFixture, SharedComponentAreShallowCopiesAndCacheNgpInsta
   Kokkos::View<double*, Kokkos::HostSpace> managed_view("cached_shared_value", 1);
   managed_view(0) = 0.75;
 
-  auto shared_component = SharedScalarComponent(managed_view);
+  SharedScalarComponent<double> shared_component(managed_view);
   auto copied_component = shared_component;
 
   copied_component(node2_)[0] = 1.75;
@@ -426,8 +438,8 @@ TEST_F(UnitTestComponentFixture, SharedComponentAssignmentRebindsToRhsState) {
   Kokkos::View<double*, Kokkos::HostSpace> rhs_view("assigned_shared_value", 1);
   rhs_view(0) = 2.5;
 
-  auto lhs_component = SharedScalarComponent(1.0);
-  auto rhs_component = SharedScalarComponent(rhs_view);
+  SharedScalarComponent<double> lhs_component(1.0);
+  SharedScalarComponent<double> rhs_component(rhs_view);
 
   lhs_component = rhs_component;
 
@@ -441,11 +453,18 @@ TEST_F(UnitTestComponentFixture, SharedComponentAssignmentRebindsToRhsState) {
   EXPECT_DOUBLE_EQ(rhs_view(0), 4.75);
 }
 
+void mutate_shared_component_on_device(const NgpSharedScalarComponent<double>& ngp_shared_component,
+                                       stk::mesh::FastMeshIndex node1_index) {
+  Kokkos::parallel_for(
+      "mutate_shared_component_on_device", Kokkos::RangePolicy<>(0, 1),
+      KOKKOS_LAMBDA(int) { ngp_shared_component(node1_index) += 0.75; });
+}
+
 TEST_F(UnitTestComponentFixture, NgpSharedComponentRoundTripHostAndDeviceMutations) {
   Kokkos::View<double*, Kokkos::HostSpace> managed_view("roundtrip_shared_value", 1);
   managed_view(0) = 0.5;
 
-  auto shared_component = SharedScalarComponent(managed_view);
+  SharedScalarComponent<double> shared_component(managed_view);
   auto ngp_shared_component = get_updated_ngp_component(shared_component);
 
   shared_component(node1_)[0] = 1.25;
@@ -455,9 +474,7 @@ TEST_F(UnitTestComponentFixture, NgpSharedComponentRoundTripHostAndDeviceMutatio
   auto ngp_mesh = stk::mesh::get_updated_ngp_mesh(bulk_data());
   stk::mesh::FastMeshIndex node1_index = ngp_mesh.fast_mesh_index(node1_);
 
-  Kokkos::parallel_for(
-      "mutate_shared_component_on_device", Kokkos::RangePolicy<>(0, 1),
-      KOKKOS_LAMBDA(int) { ngp_shared_component(node1_index) += 0.75; });
+  mutate_shared_component_on_device(ngp_shared_component, node1_index);
   Kokkos::fence();
 
   ngp_shared_component.modify_on_device();

--- a/mundy/mesh/tests/unit_tests/UnitTestLinkCOOData.cpp
+++ b/mundy/mesh/tests/unit_tests/UnitTestLinkCOOData.cpp
@@ -262,6 +262,18 @@ TEST(UnitTestLinkCOOData, NgpCOOData_Construction_IsValid) {
 
 // After declaring a relation on the host and syncing to device, a kernel must read
 // back the correct entity and rank.
+
+void cache_result(const NgpLinkCOOData& ngp_coo, stk::mesh::FastMeshIndex link_idx,
+                  Kokkos::View<stk::mesh::Entity*, stk::ngp::MemSpace> entity_result,
+                  Kokkos::View<stk::mesh::EntityRank*, stk::ngp::MemSpace> rank_result) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<stk::ngp::ExecSpace>(0, 1), KOKKOS_LAMBDA(int) {
+        entity_result(0) = ngp_coo.get_linked_entity(link_idx, 0u);
+        rank_result(0) = ngp_coo.get_linked_entity_rank(link_idx, 0u);
+      });
+  Kokkos::fence();
+}
+
 TEST(UnitTestLinkCOOData, NgpCOOData_ReflectsHostRelationsAfterSync) {
   LinkCOODataFixture f;
 
@@ -276,13 +288,7 @@ TEST(UnitTestLinkCOOData, NgpCOOData_ReflectsHostRelationsAfterSync) {
   const stk::mesh::FastMeshIndex link_idx = ngp.ngp_mesh().fast_mesh_index(f.link);
   Kokkos::View<stk::mesh::Entity*, stk::ngp::MemSpace> entity_result("entity_result", 1);
   Kokkos::View<stk::mesh::EntityRank*, stk::ngp::MemSpace> rank_result("rank_result", 1);
-
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<stk::ngp::ExecSpace>(0, 1), KOKKOS_LAMBDA(int) {
-        entity_result(0) = ngp_coo.get_linked_entity(link_idx, 0u);
-        rank_result(0) = ngp_coo.get_linked_entity_rank(link_idx, 0u);
-      });
-  Kokkos::fence();
+  cache_result(ngp_coo, link_idx, entity_result, rank_result);
 
   auto entity_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, entity_result);
   auto rank_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, rank_result);
@@ -292,6 +298,13 @@ TEST(UnitTestLinkCOOData, NgpCOOData_ReflectsHostRelationsAfterSync) {
 
 // A destroy_relation executed inside a device kernel must be visible on the host
 // after coo_sync_to_host().
+
+void destroy_relation_on_device(const NgpLinkCOOData& ngp_coo, stk::mesh::FastMeshIndex link_idx) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<stk::ngp::ExecSpace>(0, 1), KOKKOS_LAMBDA(int) { ngp_coo.destroy_relation(link_idx, 0u); });
+  Kokkos::fence();
+}
+
 TEST(UnitTestLinkCOOData, NgpCOOData_DestroyRelationOnDevice_ReflectedAfterSyncBack) {
   LinkCOODataFixture f;
 
@@ -305,9 +318,7 @@ TEST(UnitTestLinkCOOData, NgpCOOData_DestroyRelationOnDevice_ReflectedAfterSyncB
   NgpLinkCOOData ngp_coo = ngp.coo_data();
   const stk::mesh::FastMeshIndex link_idx = ngp.ngp_mesh().fast_mesh_index(f.link);
 
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<stk::ngp::ExecSpace>(0, 1), KOKKOS_LAMBDA(int) { ngp_coo.destroy_relation(link_idx, 0u); });
-  Kokkos::fence();
+  destroy_relation_on_device(ngp_coo, link_idx);
 
   ngp.coo_modify_on_device();
   ngp.coo_sync_to_host();

--- a/mundy/mesh/tests/unit_tests/UnitTestLinkDataObserver.cpp
+++ b/mundy/mesh/tests/unit_tests/UnitTestLinkDataObserver.cpp
@@ -190,7 +190,7 @@ size_t count_links(const LinkDataObserverFixture& fixture) {
 stk::mesh::Ordinal get_partition_id_for_dimensionality(const NgpLinkData& ngp_link_data, unsigned dimensionality) {
   const auto& partitions = ngp_link_data.crs_data().get_all_crs_partitions();
   for (size_t i = 0; i < partitions.extent(0); ++i) {
-    const LinkCSRPartition& partition = partitions(i);
+    const auto& partition = partitions(i);
     if (partition.link_dimensionality() == dimensionality) {
       return partition.id();
     }

--- a/mundy/search/src/mundy_search/NeighborListRebuilder.hpp
+++ b/mundy/search/src/mundy_search/NeighborListRebuilder.hpp
@@ -377,8 +377,7 @@ class RebuildOnEntityChange {
   }
   //@}
 
- private:
-  //! \name Internal helpers
+  //! \name Internal helpers TODO(palmerb4): Make these private somehow but handle CUDA's complain about device lambdas in private methods.
   //@{
 
   /// \brief Enumerate the current entities of an input's chunk into a device view (selector order).
@@ -418,6 +417,7 @@ class RebuildOnEntityChange {
     Kokkos::fence();
   }
   //@}
+ private:
 
   //! \name Internal members
   //@{


### PR DESCRIPTION
Math: Fixed a combinatoric O(N!) type growth in inverse(mat) via bitmasking + lu partial pivoting.
Math: Fixed a performance degradation of Array/Matrix/Vector/Quaternion whereby {} initialization piped though a runtime sized initializer list constructor.
Misc GPU compilation fixes to make CUDA happy and to maintain backward compatibility with Trilinos 16.0