### PR TITLE
gpu: Added do-cmake-gpu.sh that configures a GPU compilation with MPI…

### DIFF
--- a/do-cmake-gpu.sh
+++ b/do-cmake-gpu.sh
@@ -1,0 +1,197 @@
+# Usage (activate the GPU spack env FIRST so `spack find` is env-scoped):
+#   source <environment load>
+#   bash ../do-cmake-gpu.sh <tpl_location> ../ <install_location>
+#
+# NOTE: To make the build itself work, you also need to override/provide the OMPI_CXX
+# and NVCC_WRAPPER_DEFAULT_COMPILER externally. This works as the following in many
+# cases
+#   export OMPI_CXX="$(spack find --format '{prefix}' kokkos | head -1)/bin/nvcc_wrapper"
+#   export NVCC_WRAPPER_DEFAULT_COMPILER="$(command -v g++)"
+
+set -e
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <TPL_ROOT_DIR> <MUNDY_SOURCE_DIR> <INSTALL_DIR>" >&2
+  echo "  TPL_ROOT_DIR    : where mundy_tpl_deps are installed (fmt, gtest, ...)" >&2
+  echo "  MUNDY_SOURCE_DIR: path to the MuNDy source tree" >&2
+  echo "  INSTALL_DIR     : CMAKE_INSTALL_PREFIX for the MuNDy install" >&2
+  exit 1
+fi
+
+TPL_ROOT_DIR=$(readlink -f "$1")
+MUNDY_SOURCE_DIR=$(readlink -f "$2")
+INSTALL_DIR=$(readlink -m "$3")  # -m: install dir need not exist yet
+
+if [ ! -d "$TPL_ROOT_DIR" ]; then
+  echo "ERROR: TPL_ROOT_DIR does not exist or is not a directory: $1" >&2
+  exit 1
+fi
+if [ ! -d "$MUNDY_SOURCE_DIR" ]; then
+  echo "ERROR: MUNDY_SOURCE_DIR does not exist or is not a directory: $2" >&2
+  exit 1
+fi
+
+# Trilinos / Kokkos / KokkosKernels are discovered from the ACTIVE spack env's
+# DAG via env-scoped `spack find`, NOT global `spack location -i`.
+TRILINOS_SPEC=${TRILINOS_SPEC:-trilinos}
+KOKKOS_SPEC=${KOKKOS_SPEC:-kokkos}
+KOKKOS_KERNELS_SPEC=${KOKKOS_KERNELS_SPEC:-kokkos-kernels}
+
+if ! command -v spack >/dev/null 2>&1; then
+  echo "ERROR: 'spack' not found in PATH. Source your spack setup-env.sh first." >&2
+  exit 1
+fi
+if ! spack env status >/dev/null 2>&1; then
+  echo "ERROR: no spack env is active. Activate your GPU env first, e.g." >&2
+  echo "       source ~/bin/env_loads/load_tril1610_sm80_cuda1251_cascadelake.sh" >&2
+  exit 1
+fi
+
+# Resolve one prefix from the active env's DAG.
+env_prefix() { spack find --format '{prefix}' "$1" | head -n1; }
+
+TRILINOS_ROOT_DIR=$(env_prefix "${TRILINOS_SPEC}")
+KOKKOS_ROOT_DIR=$(env_prefix "${KOKKOS_SPEC}")
+KOKKOS_KERNELS_ROOT_DIR=$(env_prefix "${KOKKOS_KERNELS_SPEC}")
+for _pair in "Trilinos:${TRILINOS_ROOT_DIR}" "Kokkos:${KOKKOS_ROOT_DIR}" "KokkosKernels:${KOKKOS_KERNELS_ROOT_DIR}"; do
+  if [ -z "${_pair#*:}" ]; then
+    echo "ERROR: could not resolve ${_pair%%:*} prefix from the active spack env." >&2
+    exit 1
+  fi
+done
+
+is_positive_integer() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# TriBITS MPI test-registration policy
+#
+# TriBITS decides which MPI tests exist at configure time. The relevant knobs
+# are defined in TriBITS' MPI/test support modules:
+#
+#   MPI_EXEC_MAX_NUMPROCS
+#     Hard cap for test registration. A test requesting more ranks than this
+#     value is not added to CTest.
+#
+#   MPI_EXEC_DEFAULT_NUMPROCS
+#     Rank count for MPI tests that do not specify NUM_MPI_PROCS. This is not
+#     a cap, so keep it <= MPI_EXEC_MAX_NUMPROCS.
+#
+# This script chooses MPI_EXEC_MAX_NUMPROCS from, in order:
+#   1. explicit MPI_EXEC_MAX_NUMPROCS
+#   2. Slurm task-count variables
+#   3. 1 inside Slurm when no task count is visible
+#   4. local CPU count outside Slurm
+#
+# The default rank count is explicit MPI_EXEC_DEFAULT_NUMPROCS when provided;
+# otherwise min(4, MPI_EXEC_MAX_NUMPROCS), matching TriBITS' default when the
+# allocation can support it.
+if [ -n "${MPI_EXEC_MAX_NUMPROCS:-}" ]; then
+  if ! is_positive_integer "$MPI_EXEC_MAX_NUMPROCS"; then
+    echo "ERROR: MPI_EXEC_MAX_NUMPROCS must be a positive integer: $MPI_EXEC_MAX_NUMPROCS" >&2
+    exit 1
+  fi
+  MPI_MAX_NUMPROCS="$MPI_EXEC_MAX_NUMPROCS"
+elif [ -n "${SLURM_STEP_NUM_TASKS:-}" ] && is_positive_integer "$SLURM_STEP_NUM_TASKS"; then
+  MPI_MAX_NUMPROCS="$SLURM_STEP_NUM_TASKS"
+elif [ -n "${SLURM_NTASKS:-}" ] && is_positive_integer "$SLURM_NTASKS"; then
+  MPI_MAX_NUMPROCS="$SLURM_NTASKS"
+elif [ -n "${SLURM_NPROCS:-}" ] && is_positive_integer "$SLURM_NPROCS"; then
+  MPI_MAX_NUMPROCS="$SLURM_NPROCS"
+elif [ -n "${SLURM_JOB_ID:-}" ]; then
+  MPI_MAX_NUMPROCS=1
+else
+  MPI_MAX_NUMPROCS=$(nproc 2>/dev/null || echo 1)
+  if ! is_positive_integer "$MPI_MAX_NUMPROCS"; then
+    MPI_MAX_NUMPROCS=1
+  fi
+fi
+
+if [ -n "${MPI_EXEC_DEFAULT_NUMPROCS:-}" ]; then
+  if ! is_positive_integer "$MPI_EXEC_DEFAULT_NUMPROCS"; then
+    echo "ERROR: MPI_EXEC_DEFAULT_NUMPROCS must be a positive integer: $MPI_EXEC_DEFAULT_NUMPROCS" >&2
+    exit 1
+  fi
+  MPI_DEFAULT_NUMPROCS="$MPI_EXEC_DEFAULT_NUMPROCS"
+elif [ "$MPI_MAX_NUMPROCS" -lt 4 ]; then
+  MPI_DEFAULT_NUMPROCS="$MPI_MAX_NUMPROCS"
+else
+  MPI_DEFAULT_NUMPROCS=4
+fi
+
+echo "Using Trilinos dir: $TRILINOS_ROOT_DIR"
+echo "Using Kokkos dir: $KOKKOS_ROOT_DIR"
+echo "Using TPL dir: $TPL_ROOT_DIR"
+echo "Using MuNDy source dir: $MUNDY_SOURCE_DIR"
+echo "Using install dir: $INSTALL_DIR"
+echo "Using MPI max num procs: $MPI_MAX_NUMPROCS"
+echo "Using MPI default num procs: $MPI_DEFAULT_NUMPROCS"
+
+# Launch C++ compiles via ccache if present (content-addressed object cache -> faster rebuilds).
+if command -v ccache >/dev/null 2>&1; then
+  ccache_args="-DCMAKE_CXX_COMPILER_LAUNCHER=$(command -v ccache)"
+  echo "Using ccache: $(command -v ccache)"
+else
+  ccache_args=""
+  echo "ccache not found on PATH; building without it"
+fi
+
+# CUDA compile wiring
+NVCC_WRAPPER="${KOKKOS_ROOT_DIR}/bin/nvcc_wrapper"
+if [ ! -x "$NVCC_WRAPPER" ]; then
+  echo "ERROR: nvcc_wrapper not found or not executable at: $NVCC_WRAPPER" >&2
+  exit 1
+fi
+export OMPI_CXX="$NVCC_WRAPPER"
+export NVCC_WRAPPER_DEFAULT_COMPILER="${NVCC_WRAPPER_DEFAULT_COMPILER:-$(command -v g++ || true)}"
+if [ -z "$NVCC_WRAPPER_DEFAULT_COMPILER" ]; then
+  echo "ERROR: no g++ on PATH for NVCC_WRAPPER_DEFAULT_COMPILER (load your gcc module)." >&2
+  exit 1
+fi
+echo "Using nvcc_wrapper (OMPI_CXX): $OMPI_CXX"
+echo "Using host compiler (NVCC_WRAPPER_DEFAULT_COMPILER): $NVCC_WRAPPER_DEFAULT_COMPILER"
+
+cmake \
+-DCMAKE_BUILD_TYPE=${BUILD_TYPE:-RELEASE} \
+-DCMAKE_CXX_COMPILER=mpicxx \
+-DCMAKE_CXX_FLAGS="-O3 -march=native" \
+-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+-DCTEST_BUILD_FLAGS:STRING="${CTEST_BUILD_FLAGS:--j8}" \
+-DCTEST_PARALLEL_LEVEL:STRING="${CTEST_PARALLEL_LEVEL:-8}" \
+-DCTEST_BUILD_NAME:STRING="${CTEST_BUILD_NAME:-mundy-gpu-local}" \
+-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
+-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+-DTPL_ENABLE_MPI=ON \
+-DMPI_EXEC_MAX_NUMPROCS:STRING=${MPI_MAX_NUMPROCS} \
+-DMPI_EXEC_DEFAULT_NUMPROCS:STRING=${MPI_DEFAULT_NUMPROCS} \
+-DMundy_ENABLE_MundyCore=ON \
+-DMundy_ENABLE_MundyMath=ON \
+-DMundy_ENABLE_MundyGeom=ON \
+-DMundy_ENABLE_MundyMesh=ON \
+-DMundy_ENABLE_MundySearch=ON \
+-DMundy_ENABLE_TESTS=ON \
+-DMundy_ENABLE_GTest=ON \
+-DMundy_ENABLE_ArborX=ON \
+-DMundy_ENABLE_STKFMM=OFF \
+-DMundy_ENABLE_PVFMM=OFF \
+-DMundy_ENABLE_KokkosKernels=ON \
+-DMundy_ENABLE_Tpetra=${MUNDY_ENABLE_TPETRA:-OFF} \
+-DMundy_ENABLE_Belos=${MUNDY_ENABLE_BELOS:-OFF} \
+-DMundy_TEST_CATEGORIES="BASIC;CONTINUOUS;NIGHTLY;HEAVY;PERFORMANCE" \
+-DTPL_GTest_DIR:PATH=${TPL_ROOT_DIR} \
+-DTPL_ArborX_DIR:PATH=${TPL_ROOT_DIR} \
+-DTPL_nanobench_DIR:PATH=${TPL_ROOT_DIR} \
+-DTPL_OpenRAND_DIR:PATH=${TPL_ROOT_DIR} \
+-DTPL_fmt_DIR:PATH=${TPL_ROOT_DIR} \
+-DTPL_Kokkos_DIR:PATH=${KOKKOS_ROOT_DIR} \
+-DTPL_KokkosKernels_DIR:PATH=${KOKKOS_KERNELS_ROOT_DIR} \
+-DTPL_STK_DIR:PATH=${TRILINOS_ROOT_DIR} \
+-DTPL_Teuchos_DIR:PATH=${TRILINOS_ROOT_DIR} \
+-DTPL_Tpetra_DIR:PATH=${TRILINOS_ROOT_DIR} \
+-DTPL_Belos_DIR:PATH=${TRILINOS_ROOT_DIR} \
+${ccache_args} \
+${MUNDY_SOURCE_DIR}


### PR DESCRIPTION
… enabled. This defaults to using the Ngp backend CUDA. You must set the OMPI_CXX and NVCC_WRAPPER_DEFAULT_COMPILER environment variables for the make portion of the call (cmake will automatically detect these during the configure phase).